### PR TITLE
wlib linking issue fixed by modifying cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(EmbeddedTests)
 
-add_definitions(-std=gnu++0x)
-add_definitions(-D_EMULATE_GLIBC=0)
+SET(CMAKE_CXX_STANDARD 14)
 
 add_subdirectory(gtest-1.8.0)
-
-include_directories(wlib)
-
 add_subdirectory(wlib)
 add_subdirectory(tests)
-
-
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,17 @@
-include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+project(tests)
+
+set(GTEST_INCLUDE_DIR ${gtest_SOURCE_DIR}/include)
+set(WLIB_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/wlib)
 
 file(GLOB files
-        "strings/*.cpp"
-        "strings2/*.cpp"
-        "strings/*.cc")
+        "strings/*.cpp")
+
+include_directories(${GTEST_INCLUDE_DIR} ${gtest_SOURCE_DIR})
+include_directories(${WLIB_INCLUDE_DIR})
 
 add_executable(Tests ${files})
 
 target_link_libraries(Tests gtest gtest_main)
-target_link_libraries(wlib)
+target_link_libraries(Tests wlib)
+ADD_DEPENDENCIES(Tests wlib)
+ADD_DEPENDENCIES(Tests gtest)

--- a/wlib/CMakeLists.txt
+++ b/wlib/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(wlib)
 
 file (GLOB header_files
+        "Wlib.h"
         "strings/*.h"
         "stl/*.h"
         "memory/*.h")
@@ -8,9 +9,7 @@ file (GLOB header_files
 file (GLOB source_files
         "memory/*.cpp")
 
-
-set(HEADER_FILES ${header_files} Wlib.h)
-
+set(HEADER_FILES ${header_files} )
 set(SOURCE_FILES ${source_files})
 
 add_library(wlib STATIC ${SOURCE_FILES} ${HEADER_FILES})


### PR DESCRIPTION
Fix for linking issue caused by the use Memory.h. The basic problem was that the CMake was building the project before building Wlib library.