### PR TITLE
[Enhancement/Cleanup] Mixed in const iterators with iterator

### DIFF
--- a/lib/wlib/stl/ArrayList.h
+++ b/lib/wlib/stl/ArrayList.h
@@ -26,15 +26,18 @@ namespace wlp {
 
     /**
      * Array list forward iterator type.
+     *
      * @tparam T list element type
+     * @tparam Ref reference type, which may be const
+     * @tparam Ptr pointer type, which may be const
      */
-    template<typename T>
+    template<typename T, typename Ref, typename Ptr>
     class ArrayListIterator {
     public:
         typedef wlp::size_type size_type;
         typedef T val_type;
         typedef ArrayList<T> array_list;
-        typedef ArrayListIterator<T> iterator;
+        typedef ArrayListIterator<T, Ref, Ptr> self_type;
 
     private:
         /**
@@ -44,7 +47,7 @@ namespace wlp {
         /**
          * Pointer to the backing array list.
          */
-        array_list *m_list;
+        const array_list *m_list;
 
         friend class ArrayList<T>;
 
@@ -62,7 +65,7 @@ namespace wlp {
          *
          * @param it iterator to copy
          */
-        ArrayListIterator(const iterator &it)
+        ArrayListIterator(const self_type &it)
                 : m_i(it.m_i),
                   m_list(it.m_list) {
             check_bounds();
@@ -75,7 +78,7 @@ namespace wlp {
          * @param i array index
          * @param list backing array list
          */
-        explicit ArrayListIterator(const size_type &i, array_list *list)
+        explicit ArrayListIterator(const size_type &i, const array_list *list)
                 : m_i(i),
                   m_list(list) {
             check_bounds();
@@ -117,7 +120,7 @@ namespace wlp {
          *
          * @return reference to this iterator
          */
-        iterator &operator++() {
+        self_type &operator++() {
             if (m_i == m_list->m_size) {
                 return *this;
             }
@@ -131,8 +134,8 @@ namespace wlp {
          *
          * @return copy of this iterator before increment
          */
-        iterator operator++(int) {
-            iterator tmp = *this;
+        self_type operator++(int) {
+            self_type tmp = *this;
             ++*this;
             return tmp;
         }
@@ -145,7 +148,7 @@ namespace wlp {
          * @param d the number of positions to increment
          * @return reference to this iterator
          */
-        iterator &operator+=(const size_type &d) {
+        self_type &operator+=(const size_type &d) {
             m_i = static_cast<size_type>(m_i + d);
             if (m_i > m_list->m_size) {
                 m_i = m_list->m_size;
@@ -160,7 +163,7 @@ namespace wlp {
          *
          * @return reference to this iterator
          */
-        iterator &operator--() {
+        self_type &operator--() {
             if (m_i == 0) {
                 return *this;
             }
@@ -173,8 +176,8 @@ namespace wlp {
          *
          * @return a copy of the iterator before moving
          */
-        iterator operator--(int) {
-            iterator tmp = *this;
+        self_type operator--(int) {
+            self_type tmp = *this;
             --*this;
             return tmp;
         }
@@ -186,7 +189,7 @@ namespace wlp {
          * @param d the number of elements to move back
          * @return reference to this iterator
          */
-        iterator &operator-=(const size_type &d) {
+        self_type &operator-=(const size_type &d) {
             if (d >= m_i) {
                 m_i = 0;
             } else {
@@ -199,7 +202,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they point to the same element
          */
-        bool operator==(const iterator &it) const {
+        bool operator==(const self_type &it) const {
             return m_i == it.m_i;
         }
 
@@ -207,7 +210,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they point to different elements
          */
-        bool operator!=(const iterator &it) const {
+        bool operator!=(const self_type &it) const {
             return m_i != it.m_i;
         }
 
@@ -217,7 +220,7 @@ namespace wlp {
          * @param it iterator to copy
          * @return reference to this iterator
          */
-        iterator &operator=(const iterator &it) {
+        self_type &operator=(const self_type &it) {
             m_i = it.m_i;
             m_list = it.m_list;
             return *this;
@@ -230,8 +233,8 @@ namespace wlp {
          * @param d number of positions to increment
          * @return
          */
-        iterator operator+(const size_type &d) const {
-            return iterator(static_cast<size_type>(m_i + d), m_list);
+        self_type operator+(const size_type &d) const {
+            return self_type(static_cast<size_type>(m_i + d), m_list);
         }
 
         /**
@@ -241,8 +244,8 @@ namespace wlp {
          * @param d number of positions to decrement
          * @return a new iterator
          */
-        iterator operator-(const size_type &d) const {
-            return iterator(static_cast<size_type>(m_i - d), m_list);
+        self_type operator-(const size_type &d) const {
+            return self_type(static_cast<size_type>(m_i - d), m_list);
         }
 
         /**
@@ -252,138 +255,7 @@ namespace wlp {
          * @param it iterator to subtract
          * @return the integer distance
          */
-        size_type operator-(const iterator &it) const {
-            if (m_i < it.m_i) {
-                return static_cast<size_type>(it.m_i - m_i);
-            }
-            return static_cast<size_type>(m_i - it.m_i);
-        }
-
-    };
-
-    /**
-     * Const iterator for array list.
-     *
-     * @see ArrayListIterator
-     * @tparam T iterator value type
-     */
-    template<typename T>
-    class ArrayListConstIterator {
-    public:
-        typedef wlp::size_type size_type;
-        typedef T val_type;
-        typedef ArrayList<T> array_list;
-        typedef ArrayListConstIterator<T> const_iterator;
-
-    private:
-        size_type m_i;
-        const array_list *m_list;
-
-        friend class ArrayList<T>;
-
-    public:
-        ArrayListConstIterator()
-                : m_i(static_cast<size_type>(-1)),
-                  m_list(nullptr) {
-        }
-
-        ArrayListConstIterator(const const_iterator &it)
-                : m_i(it.m_i),
-                  m_list(it.m_list) {
-            check_bounds();
-        }
-
-        explicit ArrayListConstIterator(const size_type &i, const array_list *list)
-                : m_i(i),
-                  m_list(list) {
-            check_bounds();
-        }
-
-    private:
-        void check_bounds() {
-            if (m_i > m_list->m_size) {
-                m_i = m_list->m_size;
-            }
-        }
-
-    public:
-
-        val_type &operator*() const {
-            return m_list->m_data[m_i];
-        }
-
-        val_type *operator->() const {
-            return &(operator*());
-        }
-
-        const_iterator &operator++() {
-            if (m_i == m_list->m_size) {
-                return *this;
-            }
-            ++m_i;
-            return *this;
-        }
-
-        const_iterator operator++(int) {
-            const_iterator tmp = *this;
-            ++*this;
-            return tmp;
-        }
-
-        const_iterator &operator+=(const size_type &d) {
-            m_i = static_cast<size_type>(m_i + d);
-            if (m_i > m_list->m_size) {
-                m_i = m_list->m_size;
-            }
-            return *this;
-        }
-
-        const_iterator &operator--() {
-            if (m_i == 0) {
-                return *this;
-            }
-            --m_i;
-            return *this;
-        }
-
-        const_iterator operator--(int) {
-            const_iterator tmp = *this;
-            --*this;
-            return tmp;
-        }
-
-        const_iterator &operator-=(const size_type &d) {
-            if (d >= m_i) {
-                m_i = 0;
-            } else {
-                m_i = static_cast<size_type>(m_i - d);
-            }
-            return *this;
-        }
-
-        bool operator==(const const_iterator &it) const {
-            return m_i == it.m_i;
-        }
-
-        bool operator!=(const const_iterator &it) const {
-            return m_i != it.m_i;
-        }
-
-        const_iterator &operator=(const const_iterator &it) {
-            m_i = it.m_i;
-            m_list = it.m_list;
-            return *this;
-        }
-
-        const_iterator operator+(const size_type &d) const {
-            return const_iterator(static_cast<size_type>(m_i + d), m_list);
-        }
-
-        const_iterator operator-(const size_type &d) const {
-            return const_iterator(static_cast<size_type>(m_i - d), m_list);
-        }
-
-        size_type operator-(const const_iterator &it) const {
+        size_type operator-(const self_type &it) const {
             if (m_i < it.m_i) {
                 return static_cast<size_type>(it.m_i - m_i);
             }
@@ -404,8 +276,8 @@ namespace wlp {
         typedef wlp::size_type size_type;
         typedef T val_type;
         typedef ArrayList<T> array_list;
-        typedef ArrayListIterator<T> iterator;
-        typedef ArrayListConstIterator<T> const_iterator;
+        typedef ArrayListIterator<T, T &, T *> iterator;
+        typedef ArrayListIterator<T, const T &, const T *> const_iterator;
 
     private:
         /**
@@ -421,9 +293,8 @@ namespace wlp {
          */
         size_type m_capacity;
 
-        friend class ArrayListIterator<T>;
-
-        friend class ArrayListConstIterator<T>;
+        friend class ArrayListIterator<T, T &, T *>;
+        friend class ArrayListIterator<T, const T &, const T *>;
 
     public:
         /**

--- a/lib/wlib/stl/ChainMap.h
+++ b/lib/wlib/stl/ChainMap.h
@@ -23,25 +23,11 @@
 namespace wlp {
 
     // Forward declaration of ChainHashMap
-    template<class Key,
+    template<typename Key,
             class Val,
-            class Hasher,
-            class Equals>
+            typename Hasher,
+            typename Equals>
     class ChainHashMap;
-
-    // Forward declaration of ChainHashMap iterator
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct ChainHashMapIterator;
-
-    // Forward declaration of const ChainHashMap iterator
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct ChainHashMapConstIterator;
 
     /**
      * Hasher map node comprise the elements of a hash map's
@@ -50,7 +36,7 @@ namespace wlp {
      * @tparam Key key type
      * @tparam Val value type
      */
-    template<class Key, class Val>
+    template<typename Key, class Val>
     struct ChainHashMapNode {
         typedef ChainHashMapNode<Key, Val> node_type;
         typedef Key key_type;
@@ -87,14 +73,16 @@ namespace wlp {
      * @tparam Hasher  hash function
      * @tparam Equals key equality function
      */
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
+    template<typename Key,
+            typename Val,
+            typename Ref,
+            typename Ptr,
+            typename Hasher,
+            typename Equals>
     struct ChainHashMapIterator {
         typedef ChainHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef ChainHashMapIterator<Key, Val, Hasher, Equals> iterator;
         typedef ChainHashMapNode<Key, Val> node_type;
+        typedef ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> self_type;
 
         typedef Val val_type;
 
@@ -107,7 +95,7 @@ namespace wlp {
         /**
          * Pointer to the iterated ChainHashMap.
          */
-        map_type *m_hash_map;
+        const map_type *m_hash_map;
 
         /**
          * Default constructor.
@@ -122,7 +110,7 @@ namespace wlp {
          * @param node hash map node
          * @param map  parent hash map
          */
-        ChainHashMapIterator(node_type *node, map_type *map)
+        ChainHashMapIterator(node_type *node, const map_type *map)
                 : m_current(node),
                   m_hash_map(map) {
         }
@@ -131,7 +119,7 @@ namespace wlp {
          * Copy constructor for const.
          * @param it iterator copy
          */
-        ChainHashMapIterator(const iterator &it)
+        ChainHashMapIterator(const self_type &it)
                 : m_current(it.m_current),
                   m_hash_map(it.m_hash_map) {
         }
@@ -158,20 +146,20 @@ namespace wlp {
          * iterator. This is pre-fix unary operator.
          * @return this iterator
          */
-        iterator &operator++();
+        self_type &operator++();
 
         /**
          * Post-fix unary operator.
          * @return this iterator
          */
-        iterator operator++(int);
+        self_type operator++(int);
 
         /**
          * Equality operator for const.
          * @param it iterator to compare
          * @return true if they are equal
          */
-        bool operator==(const iterator &it) const {
+        bool operator==(const self_type &it) const {
             return m_current == it.m_current;
         }
 
@@ -181,7 +169,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they point to different nodes
          */
-        bool operator!=(const iterator &it) const {
+        bool operator!=(const self_type &it) const {
             return m_current != it.m_current;
         }
 
@@ -191,77 +179,7 @@ namespace wlp {
          * @param it iterator to copy
          * @return reference to this iterator
          */
-        iterator &operator=(const iterator &it) {
-            m_current = it.m_current;
-            m_hash_map = it.m_hash_map;
-            return *this;
-        }
-
-    };
-
-    /**
-     * Constant iterator over a ChainHashMap. Values iterated by
-     * this class cannot be modified.
-     *
-     * @see ChainHashMapIterator
-     *
-     * @tparam Key   key type
-     * @tparam Val   value type
-     * @tparam Hasher  hash function
-     * @tparam Equals key equality function
-     */
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct ChainHashMapConstIterator {
-        typedef ChainHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef ChainHashMapConstIterator<Key, Val, Hasher, Equals> const_iterator;
-        typedef ChainHashMapNode<Key, Val> node_type;
-
-        typedef Val val_type;
-
-        typedef wlp::size_type size_type;
-
-        const node_type *m_current;
-        const map_type *m_hash_map;
-
-        ChainHashMapConstIterator()
-                : m_current(nullptr),
-                  m_hash_map(nullptr) {
-        }
-
-        ChainHashMapConstIterator(node_type *node, const map_type *map)
-                : m_current(node),
-                  m_hash_map(map) {
-        }
-
-        ChainHashMapConstIterator(const const_iterator &it)
-                : m_current(it.m_current),
-                  m_hash_map(it.m_hash_map) {
-        }
-
-        const val_type &operator*() const {
-            return m_current->m_val;
-        }
-
-        const val_type *operator->() const {
-            return &(operator*());
-        }
-
-        const_iterator &operator++();
-
-        const_iterator operator++(int);
-
-        bool operator==(const const_iterator &it) const {
-            return m_current == it.m_current;
-        }
-
-        bool operator!=(const const_iterator &it) const {
-            return m_current != it.m_current;
-        }
-
-        const_iterator &operator=(const const_iterator &it) {
+        self_type &operator=(const self_type &it) {
             m_current = it.m_current;
             m_hash_map = it.m_hash_map;
             return *this;
@@ -277,15 +195,15 @@ namespace wlp {
      * @tparam Hasher  hash function
      * @tparam Equals key equality function
      */
-    template<class Key,
-            class Val,
-            class Hasher = Hash<Key, uint16_t>,
-            class Equals = Equal<Key>>
+    template<typename Key,
+            typename Val,
+            typename Hasher = Hash<Key, uint16_t>,
+            typename Equals = Equal<Key>>
     class ChainHashMap {
     public:
         typedef ChainHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef ChainHashMapIterator<Key, Val, Hasher, Equals> iterator;
-        typedef ChainHashMapConstIterator<Key, Val, Hasher, Equals> const_iterator;
+        typedef ChainHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals> iterator;
+        typedef ChainHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals> const_iterator;
         typedef ChainHashMapNode<Key, Val> node_type;
 
         typedef Key key_type;
@@ -294,8 +212,8 @@ namespace wlp {
         typedef wlp::size_type size_type;
         typedef uint8_t percent_type;
 
-        friend struct ChainHashMapIterator<Key, Val, Hasher, Equals>;
-        friend struct ChainHashMapConstIterator<Key, Val, Hasher, Equals>;
+        friend struct ChainHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals>;
+        friend struct ChainHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals>;
 
     private:
         /**
@@ -486,7 +404,7 @@ namespace wlp {
         }
 
         /**
-         * @see ChainHashMap<Key, Value, Hasher, Equals>::begin()
+         * @see ChainHashMap<Key, Val, Hasher, Equals>::begin()
          * @return a constant iterator to the first element
          */
         const_iterator begin() const {
@@ -502,7 +420,7 @@ namespace wlp {
         }
 
         /**
-         * @see ChainHashMap<Key, Value, Hasher, Equals>::end()
+         * @see ChainHashMap<Key, Val, Hasher, Equals>::end()
          * @return a constant pass-the-end iterator
          */
         const_iterator end() const {
@@ -570,7 +488,7 @@ namespace wlp {
         iterator at(const key_type &key);
 
         /**
-         * @see ChainHashMap<Key, Value, Hasher, Equals>::at()
+         * @see ChainHashMap<Key, Val, Hasher, Equals>::at()
          * @param key key for which to find the value
          * @return the mapped value
          * @throws KeyException if the key does not exist
@@ -594,7 +512,7 @@ namespace wlp {
         iterator find(const key_type &key);
 
         /**
-         * @see ChainHashMap<Key, Value, Hasher, Equals>::find()
+         * @see ChainHashMap<Key, Val, Hasher, Equals>::find()
          * @param key the key to map
          * @return a const iterator to the element mapped by the key
          */
@@ -631,16 +549,16 @@ namespace wlp {
         map_type &operator=(map_type &&map);
     };
 
-    template<class Key, class Value, class Hasher, class Equals>
-    void ChainHashMap<Key, Value, Hasher, Equals>::init_buckets(ChainHashMap<Key, Value, Hasher, Equals>::size_type n) {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    void ChainHashMap<Key, Val, Hasher, Equals>::init_buckets(ChainHashMap<Key, Val, Hasher, Equals>::size_type n) {
         m_buckets = malloc<node_type *>(n);
         for (size_type i = 0; i < n; ++i) {
             m_buckets[i] = nullptr;
         }
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    void ChainHashMap<Key, Value, Hasher, Equals>::ensure_capacity() {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    void ChainHashMap<Key, Val, Hasher, Equals>::ensure_capacity() {
         if (m_num_elements * 100 < m_max_load * m_capacity) {
             return;
         }
@@ -668,8 +586,8 @@ namespace wlp {
         m_capacity = new_capacity;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    void ChainHashMap<Key, Value, Hasher, Equals>::clear() noexcept {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    void ChainHashMap<Key, Val, Hasher, Equals>::clear() noexcept {
         for (size_type i = 0; i < m_capacity; ++i) {
             node_type *cur = m_buckets[i];
             node_type *next;
@@ -683,7 +601,7 @@ namespace wlp {
         m_num_elements = 0;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, class Val, typename Hasher, typename Equals>
     template<typename K, typename V>
     Pair<typename ChainHashMap<Key, Val, Hasher, Equals>::iterator, bool>
     ChainHashMap<Key, Val, Hasher, Equals>::insert(K &&key, V &&val) {
@@ -704,7 +622,7 @@ namespace wlp {
         return Pair<iterator, bool>(iterator(tmp, this), true);
     };
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, class Val, typename Hasher, typename Equals>
     template<typename K, typename V>
     Pair<typename ChainHashMap<Key, Val, Hasher, Equals>::iterator, bool>
     ChainHashMap<Key, Val, Hasher, Equals>::insert_or_assign(K &&key, V &&val) {
@@ -726,9 +644,9 @@ namespace wlp {
         return Pair<iterator, bool>(iterator(tmp, this), true);
     };
 
-    template<class Key, class Value, class Hasher, class Equals>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::iterator
-    ChainHashMap<Key, Value, Hasher, Equals>::erase(const iterator &pos) {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    typename ChainHashMap<Key, Val, Hasher, Equals>::iterator
+    ChainHashMap<Key, Val, Hasher, Equals>::erase(const iterator &pos) {
         node_type *p_node = pos.m_current;
         if (p_node) {
             node_type *n_node = p_node->next;
@@ -771,8 +689,8 @@ namespace wlp {
         return end();
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    bool ChainHashMap<Key, Value, Hasher, Equals>::erase(const key_type &key) {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    bool ChainHashMap<Key, Val, Hasher, Equals>::erase(const key_type &key) {
         size_type i = hash(key);
         node_type *first = m_buckets[i];
         if (first) {
@@ -811,9 +729,9 @@ namespace wlp {
         return false;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::iterator
-    ChainHashMap<Key, Value, Hasher, Equals>::at(const key_type &key) {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    typename ChainHashMap<Key, Val, Hasher, Equals>::iterator
+    ChainHashMap<Key, Val, Hasher, Equals>::at(const key_type &key) {
         size_type i = hash(key);
         node_type *cur = m_buckets[i];
         if (!cur) {
@@ -828,9 +746,9 @@ namespace wlp {
         return iterator(cur, this);
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::const_iterator
-    ChainHashMap<Key, Value, Hasher, Equals>::at(const key_type &key) const {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    typename ChainHashMap<Key, Val, Hasher, Equals>::const_iterator
+    ChainHashMap<Key, Val, Hasher, Equals>::at(const key_type &key) const {
         size_type i = hash(key);
         node_type *cur = m_buckets[i];
         if (!cur) {
@@ -845,8 +763,8 @@ namespace wlp {
         return const_iterator(cur, this);
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    bool ChainHashMap<Key, Value, Hasher, Equals>::contains(const key_type &key) const {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    bool ChainHashMap<Key, Val, Hasher, Equals>::contains(const key_type &key) const {
         size_type i = hash(key);
         node_type *cur = m_buckets[i];
         if (!cur) {
@@ -858,10 +776,10 @@ namespace wlp {
         return cur != nullptr;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     template<typename K>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::val_type &
-    ChainHashMap<Key, Value, Hasher, Equals>::operator[](K &&key) {
+    typename ChainHashMap<Key, Val, Hasher, Equals>::val_type &
+    ChainHashMap<Key, Val, Hasher, Equals>::operator[](K &&key) {
         ensure_capacity();
         size_type i = hash(key);
         node_type *first = m_buckets[i];
@@ -891,9 +809,9 @@ namespace wlp {
         return cur->m_val;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::iterator
-    ChainHashMap<Key, Value, Hasher, Equals>::find(const key_type &key) {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    typename ChainHashMap<Key, Val, Hasher, Equals>::iterator
+    ChainHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) {
         size_type i = hash(key);
         node_type *cur = m_buckets[i];
         if (!cur) {
@@ -908,9 +826,9 @@ namespace wlp {
         return iterator(cur, this);
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    typename ChainHashMap<Key, Value, Hasher, Equals>::const_iterator
-    ChainHashMap<Key, Value, Hasher, Equals>::find(const key_type &key) const {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    typename ChainHashMap<Key, Val, Hasher, Equals>::const_iterator
+    ChainHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) const {
         size_type i = hash(key);
         node_type *cur = m_buckets[i];
         if (!cur) {
@@ -925,8 +843,8 @@ namespace wlp {
         return const_iterator(cur, this);
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    ChainHashMap<Key, Value, Hasher, Equals>::~ChainHashMap() {
+    template<typename Key, typename Val, typename Hasher, typename Equals>
+    ChainHashMap<Key, Val, Hasher, Equals>::~ChainHashMap() {
         if (!m_buckets) {
             return;
         }
@@ -944,7 +862,7 @@ namespace wlp {
         m_buckets = nullptr;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, class Val, typename Hasher, typename Equals>
     ChainHashMap<Key, Val, Hasher, Equals> &
     ChainHashMap<Key, Val, Hasher, Equals>::operator=(ChainHashMap<Key, Val, Hasher, Equals> &&map) {
         clear();
@@ -959,9 +877,10 @@ namespace wlp {
         return *this;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    ChainHashMapIterator<Key, Value, Hasher, Equals> &
-    ChainHashMapIterator<Key, Value, Hasher, Equals>::operator++() {
+    template<typename Key, typename Val, typename Ref,
+            typename Ptr, typename Hasher, typename Equals>
+    typename ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::self_type &
+    ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++() {
         const node_type *old = m_current;
         m_current = m_current->next;
         if (!m_current) {
@@ -976,35 +895,11 @@ namespace wlp {
         return *this;
     }
 
-    template<class Key, class Value, class Hasher, class Equals>
-    inline ChainHashMapIterator<Key, Value, Hasher, Equals>
-    ChainHashMapIterator<Key, Value, Hasher, Equals>::operator++(int) {
-        iterator tmp = *this;
-        ++*this;
-        return tmp;
-    }
-
-    template<class Key, class Value, class Hasher, class Equals>
-    ChainHashMapConstIterator<Key, Value, Hasher, Equals> &
-    ChainHashMapConstIterator<Key, Value, Hasher, Equals>::operator++() {
-        const node_type *old = m_current;
-        m_current = m_current->next;
-        if (!m_current) {
-            size_type i = m_hash_map->hash(old->m_key);
-            while (++i < m_hash_map->m_capacity && !m_hash_map->m_buckets[i]) {}
-            if (i == m_hash_map->m_capacity) {
-                m_current = nullptr;
-            } else {
-                m_current = m_hash_map->m_buckets[i];
-            }
-        }
-        return *this;
-    }
-
-    template<class Key, class Value, class Hasher, class Equals>
-    inline ChainHashMapConstIterator<Key, Value, Hasher, Equals>
-    ChainHashMapConstIterator<Key, Value, Hasher, Equals>::operator++(int) {
-        const_iterator tmp = *this;
+    template<typename Key, typename Val, typename Ref,
+            typename Ptr, typename Hasher, typename Equals>
+    inline typename ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::self_type
+    ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++(int) {
+        self_type tmp = *this;
         ++*this;
         return tmp;
     }

--- a/lib/wlib/stl/ChainSet.h
+++ b/lib/wlib/stl/ChainSet.h
@@ -33,8 +33,8 @@ namespace wlp {
     public:
         typedef ChainHashSet<Key, Hash, Equal> set_type;
         typedef ChainHashMap<Key, Key, Hash, Equal> map_type;
-        typedef ChainHashMapIterator<Key, Key, Hash, Equal> iterator;
-        typedef ChainHashMapConstIterator<Key, Key, Hash, Equal> const_iterator;
+        typedef typename ChainHashMap<Key, Key, Hash, Equal>::iterator iterator;
+        typedef typename ChainHashMap<Key, Key, Hash, Equal>::const_iterator const_iterator;
         typedef typename map_type::size_type size_type;
         typedef typename map_type::percent_type percent_type;
         typedef typename map_type::key_type key_type;

--- a/lib/wlib/stl/LinkedList.h
+++ b/lib/wlib/stl/LinkedList.h
@@ -26,7 +26,8 @@ namespace wlp {
         typedef LinkedListNode<T> node_type;
 
         val_type m_val;
-        node_type *m_next, *m_prev;
+        node_type *m_next;
+        node_type *m_prev;
     };
 
     // Forward Declaration of List class
@@ -34,17 +35,17 @@ namespace wlp {
     class LinkedList;
 
     /**
-     * Iterator class over the elements of a List.
+     * Iterator class over the elements of a @code LinkedList @endcode.
      *
-     * @tparam T   value type
+     * @tparam T value type
      */
-    template<typename T>
+    template<typename T, typename Ref, typename Ptr>
     struct LinkedListIterator {
         typedef T val_type;
         typedef wlp::size_type size_type;
         typedef LinkedListNode<T> node_type;
-        typedef LinkedListIterator<T> iterator;
         typedef LinkedList<T> list_type;
+        typedef LinkedListIterator<T, Ref, Ptr> self_type;
 
         /**
          * Pointer to the node referenced by this iterator.
@@ -53,7 +54,7 @@ namespace wlp {
         /**
          * Pointer to the iterated List.
          */
-        list_type *m_list;
+        const list_type *m_list;
 
         /**
          * Default constructor.
@@ -68,7 +69,7 @@ namespace wlp {
          * @param node linked list node
          * @param list  parent linked list
          */
-        LinkedListIterator(node_type *node, list_type *list)
+        LinkedListIterator(node_type *node, const list_type *list)
                 : m_current(node),
                   m_list(list) {}
 
@@ -77,7 +78,7 @@ namespace wlp {
          *
          * @param it iterator copy
          */
-        LinkedListIterator(const iterator &it)
+        LinkedListIterator(const self_type &it)
                 : m_current(it.m_current),
                   m_list(it.m_list) {}
 
@@ -104,7 +105,7 @@ namespace wlp {
          *
          * @return this iterator
          */
-        iterator &operator++() {
+        self_type &operator++() {
             if (m_current) {
                 m_current = m_current->m_next;
             }
@@ -116,8 +117,8 @@ namespace wlp {
          *
          * @return this iterator
          */
-        iterator operator++(int) {
-            iterator clone(*this);
+        self_type operator++(int) {
+            self_type clone(*this);
             ++*this;
             return clone;
         }
@@ -130,7 +131,7 @@ namespace wlp {
          *
          * @return reference to this iterator
          */
-        iterator &operator--() {
+        self_type &operator--() {
             if (m_current && m_current != m_list->m_head) {
                 m_current = m_current->m_prev;
             }
@@ -142,8 +143,8 @@ namespace wlp {
          *
          * @return reference to this iterator
          */
-        iterator operator--(int) {
-            iterator clone(*this);
+        self_type operator--(int) {
+            self_type clone(*this);
             --*this;
             return *this;
         }
@@ -154,7 +155,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they are equal
          */
-        bool operator==(const iterator &it) const {
+        bool operator==(const self_type &it) const {
             return m_current == it.m_current;
         }
 
@@ -165,7 +166,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they point to different nodes
          */
-        bool operator!=(const iterator &it) const {
+        bool operator!=(const self_type &it) const {
             return m_current != it.m_current;
         }
 
@@ -176,86 +177,7 @@ namespace wlp {
          * @param it iterator to copy
          * @return reference to this iterator
          */
-        iterator &operator=(const iterator &it) {
-            m_current = it.m_current;
-            m_list = it.m_list;
-            return *this;
-        }
-    };
-
-    /**
-     * Constant iterator over a List. Values iterated by
-     * this class cannot be modified.
-     *
-     * @see ListIterator
-     * @tparam T value type
-     */
-    template<typename T>
-    struct LinkedListConstIterator {
-        typedef T val_type;
-        typedef wlp::size_type size_type;
-        typedef LinkedListNode<T> node_type;
-        typedef LinkedListConstIterator<T> const_iterator;
-        typedef LinkedList<T> list_type;
-
-        const node_type *m_current;
-        const list_type *m_list;
-
-        LinkedListConstIterator()
-                : m_current(nullptr),
-                  m_list(nullptr) {}
-
-        LinkedListConstIterator(const node_type *node, const list_type *list)
-                : m_current(node),
-                  m_list(list) {}
-
-        LinkedListConstIterator(const const_iterator &it)
-                : m_current(it.m_current),
-                  m_list(it.m_list) {}
-
-        const val_type &operator*() const {
-            return m_current->m_val;
-        }
-
-        const val_type *operator->() const {
-            return &(operator*());
-        }
-
-        const_iterator &operator++() {
-            if (m_current) {
-                m_current = m_current->m_next;
-            }
-            return *this;
-        }
-
-        const_iterator operator++(int) {
-            const_iterator clone(*this);
-            ++*this;
-            return clone;
-        }
-
-        const_iterator &operator--() {
-            if (m_current && m_current != m_list->m_head) {
-                m_current = m_current->m_prev;
-            }
-            return *this;
-        }
-
-        const_iterator operator--(int) {
-            const_iterator clone(*this);
-            --*this;
-            return *this;
-        }
-
-        bool operator==(const const_iterator &it) const {
-            return m_current == it.m_current;
-        }
-
-        bool operator!=(const const_iterator &it) const {
-            return m_current != it.m_current;
-        }
-
-        const_iterator &operator=(const const_iterator &it) {
+        self_type &operator=(const self_type &it) {
             m_current = it.m_current;
             m_list = it.m_list;
             return *this;
@@ -274,8 +196,8 @@ namespace wlp {
         typedef wlp::size_type size_type;
         typedef LinkedList<T> list_type;
         typedef LinkedListNode<T> node_type;
-        typedef LinkedListIterator<T> iterator;
-        typedef LinkedListConstIterator<T> const_iterator;
+        typedef LinkedListIterator<T, T &, T *> iterator;
+        typedef LinkedListIterator<T, const T &, const T *> const_iterator;
 
     private:
         /**
@@ -291,9 +213,8 @@ namespace wlp {
          */
         node_type *m_tail;
 
-        friend struct LinkedListIterator<T>;
-
-        friend struct LinkedListConstIterator<T>;
+        friend struct LinkedListIterator<T, T &, T *>;
+        friend struct LinkedListIterator<T, const T &, const T *>;
 
     public:
         /**

--- a/lib/wlib/stl/OpenMap.h
+++ b/lib/wlib/stl/OpenMap.h
@@ -25,25 +25,11 @@
 namespace wlp {
 
     // Forward declaration of OpenHashMap
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
+    template<typename Key,
+            typename Val,
+            typename Hasher,
+            typename Equals>
     class OpenHashMap;
-
-    // Forward declaration of OpenHashMap iterator
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct OpenHashMapIterator;
-
-    // Forward declaration of const OpenHashMap iterator
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct OpenHashMapConstIterator;
 
     /**
      * Hasher map node comprise the elements of a hash map's
@@ -51,7 +37,7 @@ namespace wlp {
      * @tparam Key key type
      * @tparam Val value type
      */
-    template<class Key, class Val>
+    template<typename Key, class Val>
     struct OpenHashMapNode {
         typedef OpenHashMapNode<Key, Val> node_type;
         typedef Key key_type;
@@ -84,14 +70,16 @@ namespace wlp {
      * @tparam Hasher  hash function
      * @tparam Equals key equality function
      */
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
+    template<typename Key,
+            typename Val,
+            typename Ref,
+            typename Ptr,
+            typename Hasher,
+            typename Equals>
     struct OpenHashMapIterator {
         typedef OpenHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef OpenHashMapIterator<Key, Val, Hasher, Equals> iterator;
         typedef OpenHashMapNode<Key, Val> node_type;
+        typedef OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> self_type;
 
         typedef Val val_type;
 
@@ -104,7 +92,7 @@ namespace wlp {
         /**
          * Pointer to the iterated OpenHashMap.
          */
-        map_type *m_hash_map;
+        const map_type *m_hash_map;
 
         /**
          * Default constructor.
@@ -119,7 +107,7 @@ namespace wlp {
          * @param node hash map node
          * @param map  parent hash map
          */
-        OpenHashMapIterator(node_type *node, map_type *map)
+        OpenHashMapIterator(node_type *node, const map_type *map)
                 : m_current(node),
                   m_hash_map(map) {
         }
@@ -128,7 +116,7 @@ namespace wlp {
          * Copy constructor for const.
          * @param it iterator to copy
          */
-        OpenHashMapIterator(const iterator &it)
+        OpenHashMapIterator(const self_type &it)
                 : m_current(it.m_current),
                   m_hash_map(it.m_hash_map) {
         }
@@ -155,13 +143,13 @@ namespace wlp {
          * iterator. This is pre-fix unary operator.
          * @return this iterator
          */
-        iterator &operator++();
+        self_type &operator++();
 
         /**
          * Post-fix unary operator.
          * @return this iterator
          */
-        iterator operator++(int);
+        self_type operator++(int);
 
         /**
          * Compare two iterators, equal of they point to the
@@ -169,7 +157,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if both point to the same node
          */
-        bool operator==(const iterator &it) const {
+        bool operator==(const self_type &it) const {
             return m_current == it.m_current;
         }
 
@@ -179,7 +167,7 @@ namespace wlp {
          * @param it iterator to compare
          * @return true if they point to different nodes
          */
-        bool operator!=(const iterator &it) const {
+        bool operator!=(const self_type &it) const {
             return m_current != it.m_current;
         }
 
@@ -189,77 +177,7 @@ namespace wlp {
          * @param it iterator to copy
          * @return a reference to this iterator
          */
-        iterator &operator=(const iterator &it) {
-            m_current = it.m_current;
-            m_hash_map = it.m_hash_map;
-            return *this;
-        }
-
-    };
-
-    /**
-     * Constant iterator over a OpenHashMap. Values iterated by
-     * this class cannot be modified.
-     *
-     * @see OpenHashMapIterator
-     *
-     * @tparam Key   key type
-     * @tparam Val   value type
-     * @tparam Hasher  hash function
-     * @tparam Equals key equality function
-     */
-    template<class Key,
-            class Val,
-            class Hasher,
-            class Equals>
-    struct OpenHashMapConstIterator {
-        typedef OpenHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef OpenHashMapConstIterator<Key, Val, Hasher, Equals> const_iterator;
-        typedef OpenHashMapNode<Key, Val> node_type;
-
-        typedef Val val_type;
-
-        typedef wlp::size_type size_type;
-
-        const node_type *m_current;
-        const map_type *m_hash_map;
-
-        OpenHashMapConstIterator()
-                : m_current(nullptr),
-                  m_hash_map(nullptr) {
-        }
-
-        OpenHashMapConstIterator(node_type *node, const map_type *map)
-                : m_current(node),
-                  m_hash_map(map) {
-        }
-
-        OpenHashMapConstIterator(const const_iterator &it)
-                : m_current(it.m_current),
-                  m_hash_map(it.m_hash_map) {
-        }
-
-        const val_type &operator*() const {
-            return m_current->m_val;
-        }
-
-        const val_type *operator->() const {
-            return &(operator*());
-        }
-
-        const_iterator &operator++();
-
-        const_iterator operator++(int);
-
-        bool operator==(const const_iterator &it) const {
-            return m_current == it.m_current;
-        }
-
-        bool operator!=(const const_iterator &it) const {
-            return m_current != it.m_current;
-        }
-
-        const_iterator &operator=(const const_iterator &it) {
+        self_type &operator=(const self_type &it) {
             m_current = it.m_current;
             m_hash_map = it.m_hash_map;
             return *this;
@@ -275,16 +193,16 @@ namespace wlp {
      * @tparam Hasher  hash function
      * @tparam Equals key equality function
      */
-    template<class Key,
-            class Val,
-            class Hasher = Hash <Key, uint16_t>,
-            class Equals = Equal <Key>>
+    template<typename Key,
+            typename Val,
+            typename Hasher = Hash <Key, uint16_t>,
+            typename Equals = Equal <Key>>
     class OpenHashMap {
     public:
         typedef OpenHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef OpenHashMapIterator<Key, Val, Hasher, Equals> iterator;
-        typedef OpenHashMapConstIterator<Key, Val, Hasher, Equals> const_iterator;
         typedef OpenHashMapNode<Key, Val> node_type;
+        typedef OpenHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals> iterator;
+        typedef OpenHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals> const_iterator;
 
         typedef Key key_type;
         typedef Val val_type;
@@ -292,8 +210,8 @@ namespace wlp {
         typedef wlp::size_type size_type;
         typedef uint8_t percent_type;
 
-        friend struct OpenHashMapIterator<Key, Val, Hasher, Equals>;
-        friend struct OpenHashMapConstIterator<Key, Val, Hasher, Equals>;
+        friend struct OpenHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals>;
+        friend struct OpenHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals>;
 
     private:
         /**
@@ -634,7 +552,7 @@ namespace wlp {
         map_type &operator=(map_type &&map);
     };
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     void OpenHashMap<Key, Val, Hasher, Equals>::init_buckets(OpenHashMap<Key, Val, Hasher, Equals>::size_type n) {
         m_buckets = malloc<node_type *>(n);
         for (size_type i = 0; i < n; ++i) {
@@ -642,7 +560,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     void OpenHashMap<Key, Val, Hasher, Equals>::ensure_capacity() {
         if (m_num_elements * 100 < m_max_load * m_capacity) {
             return;
@@ -670,7 +588,7 @@ namespace wlp {
         m_capacity = new_capacity;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     void OpenHashMap<Key, Val, Hasher, Equals>::clear() noexcept {
         for (size_type i = 0; i < m_capacity; ++i) {
             if (m_buckets[i]) {
@@ -681,7 +599,7 @@ namespace wlp {
         m_num_elements = 0;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     template<typename K, typename V>
     Pair<typename OpenHashMap<Key, Val, Hasher, Equals>::iterator, bool>
     OpenHashMap<Key, Val, Hasher, Equals>::insert(K &&key, V &&val) {
@@ -704,7 +622,7 @@ namespace wlp {
         }
     };
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     template<typename K, typename V>
     Pair<typename OpenHashMap<Key, Val, Hasher, Equals>::iterator, bool>
     OpenHashMap<Key, Val, Hasher, Equals>::insert_or_assign(K &&key, V &&val) {
@@ -728,7 +646,7 @@ namespace wlp {
         }
     };
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     typename OpenHashMap<Key, Val, Hasher, Equals>::iterator
     OpenHashMap<Key, Val, Hasher, Equals>::erase(const iterator &pos) {
         const node_type *cur_node = pos.m_current;
@@ -771,7 +689,7 @@ namespace wlp {
         return iterator(next_node, this);
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     bool OpenHashMap<Key, Val, Hasher, Equals>::erase(const key_type &key) {
         size_type i = hash(key);
         while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
@@ -807,7 +725,7 @@ namespace wlp {
         return true;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     typename OpenHashMap<Key, Val, Hasher, Equals>::iterator
     OpenHashMap<Key, Val, Hasher, Equals>::at(const key_type &key) {
         size_type i = hash(key);
@@ -823,7 +741,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     typename OpenHashMap<Key, Val, Hasher, Equals>::const_iterator
     OpenHashMap<Key, Val, Hasher, Equals>::at(const key_type &key) const {
         size_type i = hash(key);
@@ -839,7 +757,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     bool OpenHashMap<Key, Val, Hasher, Equals>::contains(const key_type &key) const {
         size_type i = hash(key);
         while (m_buckets[i]) {
@@ -853,7 +771,7 @@ namespace wlp {
         return false;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     template<typename K>
     typename OpenHashMap<Key, Val, Hasher, Equals>::val_type &
     OpenHashMap<Key, Val, Hasher, Equals>::operator[](K &&key) {
@@ -876,7 +794,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     typename OpenHashMap<Key, Val, Hasher, Equals>::iterator
     OpenHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) {
         size_type i = hash(key);
@@ -892,7 +810,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     typename OpenHashMap<Key, Val, Hasher, Equals>::const_iterator
     OpenHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) const {
         size_type i = hash(key);
@@ -908,7 +826,7 @@ namespace wlp {
         }
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     OpenHashMap<Key, Val, Hasher, Equals>::~OpenHashMap() {
         if (!m_buckets) {
             return;
@@ -923,7 +841,7 @@ namespace wlp {
         m_buckets = nullptr;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
+    template<typename Key, typename Val, typename Hasher, typename Equals>
     OpenHashMap<Key, Val, Hasher, Equals> &
     OpenHashMap<Key, Val, Hasher, Equals>::operator=(OpenHashMap<Key, Val, Hasher, Equals> &&map) {
         clear();
@@ -938,9 +856,9 @@ namespace wlp {
         return *this;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
-    OpenHashMapIterator<Key, Val, Hasher, Equals> &
-    OpenHashMapIterator<Key, Val, Hasher, Equals>::operator++() {
+    template<typename Key, typename Val, typename Ref, typename Ptr, typename Hasher, typename Equals>
+    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> &
+    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++() {
         size_type i = m_hash_map->hash(m_current->m_key);
         while (m_hash_map->m_buckets[i] && !m_hash_map->m_equal(m_current->m_key, m_hash_map->m_buckets[i]->m_key)) {
             if (++i >= m_hash_map->m_capacity) {
@@ -956,36 +874,10 @@ namespace wlp {
         return *this;
     }
 
-    template<class Key, class Val, class Hasher, class Equals>
-    inline OpenHashMapIterator<Key, Val, Hasher, Equals>
-    OpenHashMapIterator<Key, Val, Hasher, Equals>::operator++(int) {
-        iterator tmp = *this;
-        ++*this;
-        return tmp;
-    }
-
-    template<class Key, class Val, class Hasher, class Equals>
-    OpenHashMapConstIterator<Key, Val, Hasher, Equals> &
-    OpenHashMapConstIterator<Key, Val, Hasher, Equals>::operator++() {
-        size_type i = m_hash_map->hash(m_current->m_key);
-        while (m_hash_map->m_buckets[i] && !m_hash_map->m_equal(m_current->m_key, m_hash_map->m_buckets[i]->m_key)) {
-            if (++i >= m_hash_map->m_capacity) {
-                i = 0;
-            }
-        }
-        while (++i < m_hash_map->m_capacity && !m_hash_map->m_buckets[i]) {}
-        if (i == m_hash_map->m_capacity) {
-            m_current = nullptr;
-        } else {
-            m_current = m_hash_map->m_buckets[i];
-        }
-        return *this;
-    }
-
-    template<class Key, class Val, class Hasher, class Equals>
-    inline OpenHashMapConstIterator<Key, Val, Hasher, Equals>
-    OpenHashMapConstIterator<Key, Val, Hasher, Equals>::operator++(int) {
-        const_iterator tmp = *this;
+    template<typename Key, typename Val, typename Ref, typename Ptr, typename Hasher, typename Equals>
+    inline OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>
+    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++(int) {
+        self_type tmp = *this;
         ++*this;
         return tmp;
     }

--- a/lib/wlib/stl/OpenSet.h
+++ b/lib/wlib/stl/OpenSet.h
@@ -34,8 +34,8 @@ namespace wlp {
     public:
         typedef OpenHashSet<Key, Hash, Equal> hash_set;
         typedef OpenHashMap<Key, Key, Hash, Equal> map_type;
-        typedef OpenHashMapIterator<Key, Key, Hash, Equal> iterator;
-        typedef OpenHashMapConstIterator<Key, Key, Hash, Equal> const_iterator;
+        typedef typename OpenHashMap<Key, Key, Hash, Equal>::iterator iterator;
+        typedef typename OpenHashMap<Key, Key, Hash, Equal>::const_iterator const_iterator;
         typedef typename map_type::size_type size_type;
         typedef typename map_type::percent_type percent_type;
         typedef typename map_type::key_type key_type;

--- a/tests/stl/linked_list_check.cpp
+++ b/tests/stl/linked_list_check.cpp
@@ -5,6 +5,9 @@
 
 using namespace wlp;
 
+typedef LinkedList<int>::iterator lli_it;
+typedef LinkedList<int>::const_iterator lli_cit;
+
 TEST(list_tests, constructor_tests) {
     LinkedList<int> numlist;
     ASSERT_EQ(numlist.size(), 0);
@@ -76,7 +79,7 @@ TEST(list_tests, iterator_tests) {
     numlist.push_front(1);
     numlist.push_back(2);
     numlist.push_front(3); // 3 1 2
-    LinkedListIterator<int> it = numlist.begin();
+    lli_it it = numlist.begin();
     ASSERT_EQ(*it, 3);
     ++it;
     ASSERT_EQ(*it, 1);
@@ -86,7 +89,7 @@ TEST(list_tests, iterator_tests) {
     ++it;
     ASSERT_EQ(it, numlist.end());
     const LinkedList<int> constlist = move(numlist);
-    LinkedListConstIterator<int> it2 = constlist.begin();
+    lli_cit it2 = constlist.begin();
     ASSERT_EQ(*it2, 3);
     ++it2;
     ASSERT_EQ(*it2, 1);

--- a/tests/template_defs.h
+++ b/tests/template_defs.h
@@ -15,7 +15,7 @@ namespace wlp {
     struct Pair<uint16_t, const char *>;
 
     template
-    class ChainHashMap<StaticString<16>, StaticString<16>>;
+    class ChainHashMap<String16, String16>;
 
     template
     class ChainHashMap<uint16_t, uint16_t>;
@@ -24,44 +24,52 @@ namespace wlp {
     struct Pair<ChainHashMap<uint16_t, uint16_t>::iterator, bool>;
 
     template
-    struct Pair<ChainHashMap<StaticString<16>, StaticString<16>>::iterator, bool>;
+    struct Pair<ChainHashMap<String16, String16>::iterator, bool>;
 
     template
     struct ChainHashMapIterator<
-            StaticString<16>,
-            StaticString<16>,
-            Hash<StaticString<16>, uint16_t>,
-            Equal<StaticString<16>>>;
+            String16,
+            String16,
+            String16 &,
+            String16 *,
+            Hash<String16, uint16_t>,
+            Equal<String16>>;
 
     template
     struct ChainHashMapIterator<
             uint16_t,
             uint16_t,
+            uint16_t &,
+            uint16_t *,
             Hash<uint16_t, uint16_t>,
             Equal<uint16_t>>;
 
     template
-    struct ChainHashMapConstIterator<
-            StaticString<16>,
-            StaticString<16>,
-            Hash<StaticString<16>, uint16_t>,
-            Equal<StaticString<16>>>;
+    struct ChainHashMapIterator<
+            String16,
+            String16,
+            const String16 &,
+            const String16 *,
+            Hash<String16, uint16_t>,
+            Equal<String16>>;
 
     template
-    struct ChainHashMapConstIterator<
+    struct ChainHashMapIterator<
             uint16_t,
             uint16_t,
+            const uint16_t &,
+            const uint16_t *,
             Hash<uint16_t, uint16_t>,
             Equal<uint16_t>>;
 
     template
-    struct Equal<StaticString<8>>;
+    struct Equal<String8>;
 
     template
     struct Equal<uint16_t>;
 
     template
-    struct Hash<StaticString<8>, uint16_t>;
+    struct Hash<String8, uint16_t>;
 
     template
     struct Hash<char *, uint16_t>;
@@ -70,7 +78,7 @@ namespace wlp {
     struct Hash<uint16_t, uint16_t>;
 
     template
-    class OpenHashMap<StaticString<16>, StaticString<16>>;
+    class OpenHashMap<String16, String16>;
 
     template
     class OpenHashMap<uint16_t, uint16_t>;
@@ -79,33 +87,41 @@ namespace wlp {
     struct Pair<OpenHashMap<uint16_t, uint16_t>::iterator, bool>;
 
     template
-    struct Pair<OpenHashMap<StaticString<16>, StaticString<16>>::iterator, bool>;
+    struct Pair<OpenHashMap<String16, String16>::iterator, bool>;
 
     template
     struct OpenHashMapIterator<
-            StaticString<16>,
-            StaticString<16>,
-            Hash<StaticString<16>, uint16_t>,
-            Equal<StaticString<16>>>;
+            String16,
+            String16,
+            String16 &,
+            String16 *,
+            Hash<String16, uint16_t>,
+            Equal<String16>>;
 
     template
     struct OpenHashMapIterator<
             uint16_t,
             uint16_t,
+            uint16_t &,
+            uint16_t *,
             Hash<uint16_t, uint16_t>,
             Equal<uint16_t>>;
 
     template
-    struct OpenHashMapConstIterator<
-            StaticString<16>,
-            StaticString<16>,
-            Hash<StaticString<16>, uint16_t>,
-            Equal<StaticString<16>>>;
+    struct OpenHashMapIterator<
+            String16,
+            String16,
+            const String16 &,
+            const String16 *,
+            Hash<String16, uint16_t>,
+            Equal<String16>>;
 
     template
-    struct OpenHashMapConstIterator<
+    struct OpenHashMapIterator<
             uint16_t,
             uint16_t,
+            const uint16_t &,
+            const uint16_t *,
             Hash<uint16_t, uint16_t>,
             Equal<uint16_t>>;
 
@@ -125,16 +141,16 @@ namespace wlp {
     class StaticString<16>;
 
     template
-    class ArrayListIterator<int>;
+    class ArrayListIterator<int, int &, int *>;
 
     template
-    class ArrayListIterator<const char *>;
+    class ArrayListIterator<int, const int &, const int *>;
 
     template
-    class ArrayListConstIterator<int>;
+    class ArrayListIterator<const char *, const char *&, const char **>;
 
     template
-    class ArrayListConstIterator<const char *>;
+    class ArrayListIterator<const char *, const char *const &, const char *const *>;
 
     template
     struct Comparator<int>;
@@ -147,6 +163,12 @@ namespace wlp {
 
     template
     class LinkedList<int>;
+
+    template
+    struct LinkedListIterator<int, int &, int *>;
+
+    template
+    struct LinkedListIterator<int, const int &, const int *>;
 
 }
 


### PR DESCRIPTION
All iterators were changed to take two extra template parameters `Ref` and `Ptr` which are `Val &, Val *` and `const Val &, const Val *` for iterators and constant iterators, respectively. T

This removes the need for copy-paste code to make const iterators.