### PR TITLE
[HF] Changed iterators to return the correct reference and pointer types

### DIFF
--- a/lib/wlib/stl/ArrayList.h
+++ b/lib/wlib/stl/ArrayList.h
@@ -36,6 +36,8 @@ namespace wlp {
     public:
         typedef wlp::size_type size_type;
         typedef T val_type;
+        typedef Ref reference;
+        typedef Ptr pointer;
         typedef ArrayList<T> array_list;
         typedef ArrayListIterator<T, Ref, Ptr> self_type;
 
@@ -100,7 +102,7 @@ namespace wlp {
          * @return a reference to the value pointed to
          * by this iterator
          */
-        val_type &operator*() const {
+        reference operator*() const {
             return m_list->m_data[m_i];
         }
 
@@ -108,7 +110,7 @@ namespace wlp {
          * @return a pointer to the value pointer to
          * by this iterator
          */
-        val_type *operator->() const {
+        pointer operator->() const {
             return &(operator*());
         }
 

--- a/lib/wlib/stl/ChainMap.h
+++ b/lib/wlib/stl/ChainMap.h
@@ -85,6 +85,8 @@ namespace wlp {
         typedef ChainHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> self_type;
 
         typedef Val val_type;
+        typedef Ref reference;
+        typedef Ptr pointer;
 
         typedef wlp::size_type size_type;
 
@@ -128,7 +130,7 @@ namespace wlp {
          * @return reference to the value of the node
          * pointed to by the iterator
          */
-        val_type &operator*() const {
+        reference operator*() const {
             return m_current->m_val;
         }
 
@@ -136,7 +138,7 @@ namespace wlp {
          * @return pointer to the value of the node
          * pointed to by the iterator
          */
-        val_type *operator->() const {
+        pointer operator->() const {
             return &(operator*());
         }
 

--- a/lib/wlib/stl/LinkedList.h
+++ b/lib/wlib/stl/LinkedList.h
@@ -42,6 +42,8 @@ namespace wlp {
     template<typename T, typename Ref, typename Ptr>
     struct LinkedListIterator {
         typedef T val_type;
+        typedef Ref reference;
+        typedef Ptr pointer;
         typedef wlp::size_type size_type;
         typedef LinkedListNode<T> node_type;
         typedef LinkedList<T> list_type;
@@ -86,7 +88,7 @@ namespace wlp {
          * @return reference to the value of the node
          * pointed to by the iterator
          */
-        val_type &operator*() const {
+        reference operator*() const {
             return m_current->m_val;
         }
 
@@ -94,7 +96,7 @@ namespace wlp {
          * @return pointer to the value of the node
          * pointed to by the iterator
          */
-        val_type *operator->() const {
+        pointer operator->() const {
             return &(operator*());
         }
 

--- a/lib/wlib/stl/OpenMap.h
+++ b/lib/wlib/stl/OpenMap.h
@@ -82,6 +82,8 @@ namespace wlp {
         typedef OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> self_type;
 
         typedef Val val_type;
+        typedef Ref reference;
+        typedef Ptr pointer;
 
         typedef wlp::size_type size_type;
 
@@ -125,7 +127,7 @@ namespace wlp {
          * @return reference to the value of the node
          * pointed to by the iterator
          */
-        val_type &operator*() const {
+        reference operator*() const {
             return m_current->m_val;
         }
 
@@ -133,7 +135,7 @@ namespace wlp {
          * @return pointer to the value of the node
          * pointed to by the iterator
          */
-        val_type *operator->() const {
+        pointer operator->() const {
             return &(operator*());
         }
 


### PR DESCRIPTION
Follow up to #58 where I forgot to actually make use of the const reference and pointer types added to each iterator.