### PR TITLE
[Enhancement] Allow creation of primitive types with value

### DIFF
--- a/lib/wlib/memory/Memory.h
+++ b/lib/wlib/memory/Memory.h
@@ -83,7 +83,7 @@ template<
 T *malloc(Args... args) {
     if (wlp::is_fundamental<typename wlp::remove_extent<T>::type>::value) {
         void *memory = __memory_alloc(static_cast<wlp::size32_type>(sizeof(T)), false);
-        return static_cast<T *>(memory);
+        return new(memory) T(wlp::forward<Args>(args)...);
     }
 
     void *memory = __memory_alloc(static_cast<wlp::size32_type>(sizeof(T)), true);

--- a/tests/memory/memory_check.cpp
+++ b/tests/memory/memory_check.cpp
@@ -175,3 +175,12 @@ TEST(memory_check, free_rvalue) {
     } // ~SamplePtrContainer called on local_spc
     ASSERT_EQ(9, Sample::constr);
 }
+
+TEST(memory_check, placement_fundamental) {
+    int *i = malloc<int>(5);
+    ASSERT_EQ(5, *i);
+    free<int>(i);
+    char *l = malloc<char>('c');
+    ASSERT_EQ('c', *l);
+    free<char>(l);
+}


### PR DESCRIPTION
`malloc<int>(5)` <===> `new int(5)`