### PR TITLE
Added exceptions to STL data structures

### DIFF
--- a/lib/wlib/exceptions/Exceptions.cpp
+++ b/lib/wlib/exceptions/Exceptions.cpp
@@ -37,7 +37,7 @@ uint16_t Exception::getLineNum() { return lineNum; }
 
 void Exception::__setLineNum(uint16_t lineNum) { this->lineNum = lineNum; }
 
-void Exception::__setFileName(const char* fileName) { this->fileName = fileName; }
+void Exception::__setFileName(const char *fileName) { this->fileName = fileName; }
 
 const char *Exception::getMessage() { return message; }
 
@@ -45,7 +45,7 @@ jmp_buf *__exc_context = nullptr;
 Exception *__exception_ptr = nullptr;
 
 void __exc_clear() {
-    if (__exception_ptr == nullptr) return;
+    if (__exception_ptr == nullptr) { return; }
 
     free<Exception>(__exception_ptr);
     __exception_ptr = nullptr;
@@ -58,29 +58,23 @@ void __exc_default_handler() {
     __exc_clear();
 }
 
-class NullPtrException : public Exception {
-public:
-    NullPtrException(const char *fileName, const uint16_t lineNum, const char *message)
-            : Exception(0, fileName, lineNum, message) {}
+#define DEFINE_EXCEPTION(Index, ExceptionName) \
+class ExceptionName : public Exception { \
+public: \
+    ExceptionName(const char *fileName, const uint16_t lineNum, const char *message) \
+            : Exception(Index, fileName, lineNum, message) {} \
 };
 
-class BadAllocException : public Exception {
-public:
-    BadAllocException(const char *fileName, const uint16_t lineNum, const char *message)
-            : Exception(1, fileName, lineNum, message) {}
-};
-
-class LogicFailureException : public Exception {
-public:
-    LogicFailureException(const char *fileName, const uint16_t lineNum, const char *message)
-            : Exception(2, fileName, lineNum, message) {}
-};
-
-class RuntimeException : public Exception {
-public:
-    RuntimeException(const char *fileName, const uint16_t lineNum, const char *message)
-            : Exception(3, fileName, lineNum, message)  {}
-};
+DEFINE_EXCEPTION(0, NullPtrException)
+DEFINE_EXCEPTION(1, BadAllocException)
+DEFINE_EXCEPTION(2, LogicFailureException)
+DEFINE_EXCEPTION(3, RuntimeException)
+DEFINE_EXCEPTION(4, IllegalTransitionException)
+DEFINE_EXCEPTION(5, UnexpectedStateException)
+DEFINE_EXCEPTION(6, IndexException)
+DEFINE_EXCEPTION(7, KeyException)
+DEFINE_EXCEPTION(8, BadStateException)
+DEFINE_EXCEPTION(9, BadWeakPtrException)
 
 Exception *__new_nullptr_exception(const char *message) {
     auto *exception = malloc<NullPtrException>(__FILE__, __LINE__, message);
@@ -102,6 +96,42 @@ Exception *__new_logic_failure_exception(const char *message) {
 
 Exception *__new_runtime_exception(const char *message) {
     auto *exception = malloc<RuntimeException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_illegal_transition_exception(const char *message) {
+    auto *exception = malloc<IllegalTransitionException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_unexpected_state_exception(const char *message) {
+    auto *exception = malloc<UnexpectedStateException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_index_exception(const char *message) {
+    auto *exception = malloc<IndexException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_key_exception(const char *message) {
+    auto *exception = malloc<KeyException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_bad_state_exception(const char *message) {
+    auto *exception = malloc<BadStateException>(__FILE__, __LINE__, message);
+
+    return exception;
+}
+
+Exception *__new_bad_weak_ptr_exception(const char *message) {
+    auto *exception = malloc<BadWeakPtrException>(__FILE__, __LINE__, message);
 
     return exception;
 }

--- a/lib/wlib/exceptions/Exceptions.h
+++ b/lib/wlib/exceptions/Exceptions.h
@@ -143,9 +143,27 @@ Exception *__new_logic_failure_exception(const char *message = "");
 
 Exception *__new_runtime_exception(const char *message = "");
 
+Exception *__new_illegal_transition_exception(const char *message = "");
+
+Exception *__new_unexpected_state_exception(const char *message = "");
+
+Exception *__new_index_exception(const char *message = "");
+
+Exception *__new_key_exception(const char *message = "");
+
+Exception *__new_bad_state_exception(const char *message = "");
+
+Exception *__new_bad_weak_ptr_exception(const char *message = "");
+
 #define NULLPTR_EXCEPTION(str) __new_nullptr_exception(str)
 #define BAD_ALLOC_EXCEPTION(str) __new_bad_alloc_exception(str)
 #define LOGIC_FAILURE_EXCEPTION(str) __new_logic_failure_exception(str)
 #define RUNTIME_EXCEPTION(str) __new_runtime_exception(str)
+#define ILLEGAL_TRANSITION_EXCEPTION(str) __new_illegal_transition_exception(str)
+#define UNEXPECTED_STATE_EXCEPTION(str) __new_unexpected_state_exception(str)
+#define INDEX_EXCEPTION(str) __new_index_exception(str)
+#define KEY_EXCEPTION(str) __new_key_exception(str)
+#define BAD_STATE_EXCEPTION(str) __new_bad_state_exception(str)
+#define BAD_WEAK_PTR_EXCEPTION(str) __new_bad_weak_ptr_exception(str)
 
 #endif //EMBEDDEDCPLUSPLUS_EXCEPTIONS_H

--- a/lib/wlib/stl/ArrayList.h
+++ b/lib/wlib/stl/ArrayList.h
@@ -17,6 +17,7 @@
 
 #include "../memory/Memory.h"
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -104,11 +105,14 @@ namespace wlp {
          * by this iterator
          */
         reference operator*() const {
+            if (m_i >= m_list->m_size) {
+                THROW(INDEX_EXCEPTION("Accessing invalid iterator"))
+            }
             return m_list->m_data[m_i];
         }
 
         /**
-         * @return a pointer to the value pointer to
+         * @return a pointer to the value pointed to
          * by this iterator
          */
         pointer operator->() const {
@@ -473,6 +477,9 @@ namespace wlp {
          * @return reference to the element
          */
         val_type &at(size_type i) {
+            if (i == 0 && m_size == 0) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             normalize(i);
             return m_data[i];
         }
@@ -484,6 +491,9 @@ namespace wlp {
          * @return reference to the element
          */
         val_type const &at(size_type i) const {
+            if (i == 0 && m_size == 0) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             normalize(i);
             return m_data[i];
         }
@@ -625,6 +635,9 @@ namespace wlp {
          */
         template<typename V>
         iterator insert(const iterator &it, V &&val) {
+            if (it.m_i > m_size) {
+                return end();
+            }
             ensure_capacity();
             shift_right(it.m_i);
             m_data[it.m_i] = forward<V>(val);

--- a/lib/wlib/stl/ChainMap.h
+++ b/lib/wlib/stl/ChainMap.h
@@ -19,6 +19,7 @@
 
 #include "../memory/Memory.h"
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -131,6 +132,9 @@ namespace wlp {
          * pointed to by the iterator
          */
         reference operator*() const {
+            if (m_current == nullptr) {
+                THROW(KEY_EXCEPTION("Accessing invalid iterator"))
+            }
             return m_current->m_val;
         }
 

--- a/lib/wlib/stl/LinkedList.h
+++ b/lib/wlib/stl/LinkedList.h
@@ -15,8 +15,9 @@
 #define CORE_STL_LIST_H
 
 #include "memory/Memory.h"
-#include "memory/Allocator.h"
+
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -89,6 +90,9 @@ namespace wlp {
          * pointed to by the iterator
          */
         reference operator*() const {
+            if (m_current == nullptr) {
+                THROW(INDEX_EXCEPTION("Accessing invalid iterator"))
+            }
             return m_current->m_val;
         }
 
@@ -318,6 +322,9 @@ namespace wlp {
          * @return a reference to the value at the start of the List
          */
         val_type &front() {
+            if (m_head == nullptr) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             return m_head->m_val;
         }
 
@@ -325,6 +332,9 @@ namespace wlp {
          * @return a const reference to the value at the start of the List
          */
         const val_type &front() const {
+            if (m_head == nullptr) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             return m_head->m_val;
         }
 
@@ -332,6 +342,9 @@ namespace wlp {
          * @return a reference to the value at the end of the List
          */
         val_type &back() {
+            if (m_tail == nullptr) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             return m_tail->m_val;
         }
 
@@ -339,6 +352,9 @@ namespace wlp {
          * @return a const reference to the value at the end of the List
          */
         const val_type &back() const {
+            if (m_tail == nullptr) {
+                THROW(INDEX_EXCEPTION("Accessing empty list"))
+            }
             return m_tail->m_val;
         }
 
@@ -671,7 +687,7 @@ namespace wlp {
     LinkedList<T>::at(size_type i) {
         if (i >= m_size) {
             if (m_size) { i %= m_size; }
-            else { i = 0; }
+            else { THROW(INDEX_EXCEPTION("Accessing empty list")) }
         }
         node_type *pTmp = m_head;
         while (i-- > 0) {
@@ -685,7 +701,7 @@ namespace wlp {
     LinkedList<T>::at(size_type i) const {
         if (i >= m_size) {
             if (m_size) { i %= m_size; }
-            else { i = 0; }
+            else { THROW(INDEX_EXCEPTION("Accessing empty list")) }
         }
         node_type *pTmp = m_head;
         while (i-- > 0) {

--- a/lib/wlib/stl/OpenMap.h
+++ b/lib/wlib/stl/OpenMap.h
@@ -21,6 +21,7 @@
 
 #include "../memory/Memory.h"
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -128,6 +129,9 @@ namespace wlp {
          * pointed to by the iterator
          */
         reference operator*() const {
+            if (m_current == nullptr) {
+                THROW(KEY_EXCEPTION("Accessing invalid iterator"))
+            }
             return m_current->m_val;
         }
 

--- a/lib/wlib/stl/RedBlackTree.h
+++ b/lib/wlib/stl/RedBlackTree.h
@@ -19,6 +19,7 @@
 #include "../Types.h"
 #include "../memory/Memory.h"
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -228,6 +229,9 @@ namespace wlp {
          * pointed to by the iterator
          */
         reference operator*() const {
+            if (m_node == nullptr) {
+                THROW(KEY_EXCEPTION("Accessing invalid iterator"))
+            }
             return m_node->m_val;
         }
 

--- a/lib/wlib/stl/SharedPtr.h
+++ b/lib/wlib/stl/SharedPtr.h
@@ -584,6 +584,9 @@ namespace wlp {
         }
 
         typename add_lvalue_reference<T>::type operator*() const {
+            if (m_ptr == nullptr) {
+                THROW(NULLPTR_EXCEPTION("Shared pointer is null"))
+            }
             return *m_ptr;
         }
 

--- a/lib/wlib/stl/SharedPtr.h
+++ b/lib/wlib/stl/SharedPtr.h
@@ -22,6 +22,7 @@
 #include "../Types.h"
 #include "../utility/Tmp.h"
 #include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -109,7 +110,7 @@ namespace wlp {
         void add_locked_reference() {
             if (exchange_and_add<ptr_use_count>(&m_use_count, 1) == 0) {
                 m_use_count = 0;
-                // Bad weak pointer
+                THROW(BAD_WEAK_PTR_EXCEPTION("Locking expired weak pointer"))
             }
         }
 
@@ -450,7 +451,7 @@ namespace wlp {
     inline SharedCount<Ptr>::SharedCount(const WeakCount<Ptr> &wc)
             : m_pi(wc.m_pi) {
         if (m_pi) { m_pi->add_locked_reference(); }
-        // Else bad weak pointer
+        else { THROW(BAD_WEAK_PTR_EXCEPTION("Creating shared ptr from expired weak ptr")) }
     }
 
     template<typename T>
@@ -595,7 +596,7 @@ namespace wlp {
         }
 
         explicit operator bool() const {
-            return m_ptr == 0 ? false : true;
+            return m_ptr != 0;
         }
 
         bool unique() const {

--- a/lib/wlib/stl/UniquePtr.h
+++ b/lib/wlib/stl/UniquePtr.h
@@ -14,6 +14,7 @@
 #define EMBEDDEDCPLUSPLUS_UNIQUEPTR_H
 
 #include "../memory/Memory.h"
+#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
@@ -98,6 +99,9 @@ namespace wlp {
         }
 
         typename add_lvalue_reference<val_type>::type operator*() const {
+            if (m_ptr == nullptr) {
+                THROW(NULLPTR_EXCEPTION("Unique pointer is null"))
+            }
             return *m_ptr;
         };
 


### PR DESCRIPTION
Most classes already have built-in behaviour to gracefully handle bad accessing/inserting/erasing. Exceptions are thrown only in cases where it is impossible for the code to get around (i.e. knowingly accessing an invalid iterator)