### PR TITLE
Refractored RedBlackTree and HashMap into `Table` type

### DIFF
--- a/docs/doxygen.conf
+++ b/docs/doxygen.conf
@@ -2308,3 +2308,4 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+

--- a/lib/wlib/stl/OpenMap.h
+++ b/lib/wlib/stl/OpenMap.h
@@ -17,848 +17,158 @@
 
 #include "Equal.h"
 #include "Hash.h"
+#include "OpenTable.h"
 #include "Pair.h"
+#include "Table.h"
+#include "Tuple.h"
 
-#include "../memory/Memory.h"
 #include "../utility/Utility.h"
-#include "../exceptions/Exceptions.h"
 
 namespace wlp {
 
-    // Forward declaration of OpenHashMap
-    template<typename Key,
-            typename Val,
-            typename Hasher,
-            typename Equals>
-    class OpenHashMap;
-
     /**
-     * Hasher map node comprise the elements of a hash map's
-     * backing array, containing an element key and corresponding value.
-     * @tparam Key key type
-     * @tparam Val value type
-     */
-    template<typename Key, class Val>
-    struct OpenHashMapNode {
-        typedef OpenHashMapNode<Key, Val> node_type;
-        typedef Key key_type;
-        typedef Val val_type;
-        /**
-         * The key of the node element.
-         */
-        key_type m_key;
-        /**
-         * The value of the node element.
-         */
-        val_type m_val;
-
-        /**
-         * Nodes are equal if the keys and values are equal.
-         * @param node node to compare
-         * @return true if the keys and values are equal
-         */
-        bool operator==(const node_type &node) const {
-            return m_key == node.m_key && m_val == node.m_val;
-        }
-    };
-
-    /**
-     * Iterator class over the elements of a OpenHashMap. Specifically,
-     * this class iterates from start to end of the OpenHashMap's backing
-     * array, returning past-the-end afterwards.
-     * @tparam Key   key type
-     * @tparam Val   value type
-     * @tparam Hasher  hash function
-     * @tparam Equals key equality function
-     */
-    template<typename Key,
-            typename Val,
-            typename Ref,
-            typename Ptr,
-            typename Hasher,
-            typename Equals>
-    struct OpenHashMapIterator {
-        typedef OpenHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef OpenHashMapNode<Key, Val> node_type;
-        typedef OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> self_type;
-
-        typedef Val val_type;
-        typedef Ref reference;
-        typedef Ptr pointer;
-
-        typedef wlp::size_type size_type;
-
-        /**
-         * Pointer to the node referenced by this iterator.
-         */
-        node_type *m_current;
-        /**
-         * Pointer to the iterated OpenHashMap.
-         */
-        const map_type *m_hash_map;
-
-        /**
-         * Default constructor.
-         */
-        OpenHashMapIterator()
-                : m_current(nullptr),
-                  m_hash_map(nullptr) {
-        }
-
-        /**
-         * Create an iterator to a OpenHashMap node.
-         * @param node hash map node
-         * @param map  parent hash map
-         */
-        OpenHashMapIterator(node_type *node, const map_type *map)
-                : m_current(node),
-                  m_hash_map(map) {
-        }
-
-        /**
-         * Copy constructor for const.
-         * @param it iterator to copy
-         */
-        OpenHashMapIterator(const self_type &it)
-                : m_current(it.m_current),
-                  m_hash_map(it.m_hash_map) {
-        }
-
-        /**
-         * @return reference to the value of the node
-         * pointed to by the iterator
-         */
-        reference operator*() const {
-            if (m_current == nullptr) {
-                THROW(KEY_EXCEPTION("Accessing invalid iterator"))
-            }
-            return m_current->m_val;
-        }
-
-        /**
-         * @return pointer to the value of the node
-         * pointed to by the iterator
-         */
-        pointer operator->() const {
-            return &(operator*());
-        }
-
-        /**
-         * Increment the iterator to the next available element in
-         * the OpenHashMap. If no such element exists, returns pass-the-end
-         * iterator. This is pre-fix unary operator.
-         * @return this iterator
-         */
-        self_type &operator++();
-
-        /**
-         * Post-fix unary operator.
-         * @return this iterator
-         */
-        self_type operator++(int);
-
-        /**
-         * Compare two iterators, equal of they point to the
-         * same node.
-         * @param it iterator to compare
-         * @return true if both point to the same node
-         */
-        bool operator==(const self_type &it) const {
-            return m_current == it.m_current;
-        }
-
-        /**
-         * Compare two iterators, unequal if they point to
-         * different nodes.
-         * @param it iterator to compare
-         * @return true if they point to different nodes
-         */
-        bool operator!=(const self_type &it) const {
-            return m_current != it.m_current;
-        }
-
-        /**
-         * Assignment operator copies pointers to node
-         * and hash map.
-         * @param it iterator to copy
-         * @return a reference to this iterator
-         */
-        self_type &operator=(const self_type &it) {
-            m_current = it.m_current;
-            m_hash_map = it.m_hash_map;
-            return *this;
-        }
-
-    };
-
-    /**
-     * Hasher map implemented using open addressing and linear probing,
+     * Hash map implemented using open addressing and linear probing,
      * in the spirit of std::unordered_map.
-     * @tparam Key   key type
-     * @tparam Val   value type
-     * @tparam Hasher  hash function
+     *
+     * @tparam Key    key type
+     * @tparam Val    value type
+     * @tparam Hasher hash function
      * @tparam Equals key equality function
      */
     template<typename Key,
             typename Val,
-            typename Hasher = Hash <Key, uint16_t>,
-            typename Equals = Equal <Key>>
+            typename Hasher = Hash<Key, uint16_t>,
+            typename Equals = Equal<Key>>
     class OpenHashMap {
     public:
         typedef OpenHashMap<Key, Val, Hasher, Equals> map_type;
-        typedef OpenHashMapNode<Key, Val> node_type;
-        typedef OpenHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals> iterator;
-        typedef OpenHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals> const_iterator;
+        typedef OpenHashTable<Tuple<Key, Val>,
+                Key, Val,
+                MapGetKey<Key, Val>, MapGetVal<Key, Val>,
+                Hasher, Equals
+        > table_type;
+        typedef typename table_type::iterator iterator;
+        typedef typename table_type::const_iterator const_iterator;
+        typedef typename table_type::size_type size_type;
+        typedef typename table_type::percent_type percent_type;
 
         typedef Key key_type;
         typedef Val val_type;
 
-        typedef wlp::size_type size_type;
-        typedef uint8_t percent_type;
-
-        friend struct OpenHashMapIterator<Key, Val, Val &, Val *, Hasher, Equals>;
-        friend struct OpenHashMapIterator<Key, Val, const Val &, const Val *, Hasher, Equals>;
-
     private:
-        /**
-         * Class hash function instance. Used to hash
-         * element keys.
-         */
-        Hasher m_hash;
-        /**
-         * Class key equality function. Used to test
-         * equality of element keys.
-         */
-        Equals m_equal;
-
-        /**
-         * Hasher map backing array.
-         */
-        node_type **m_buckets;
-
-        /**
-         * The current number of elements that have been inserted
-         * into the map.
-         */
-        size_type m_num_elements;
-        /**
-         * The size of the backing array.
-         */
-        size_type m_capacity;
-        /**
-         * The load factor in integer percent
-         * before rehashing occurs. This number
-         * cannot be larger than 100.
-         */
-        percent_type m_max_load;
+        table_type m_table;
 
     public:
-        /**
-         * Create and initialize an empty hash map. The hash map uses
-         * The hash map is implemented with open addressing and linear probing.
-         *
-         * @pre the hash map requires definition of an initial bucket array size
-         *      and a maximum load factor before rehashing
-         *
-         * @param n        initial size of the bucket list; each bucket is initialized to nullptr
-         * @param max_load an integer value denoting the max percent load factory, e.g. 75 = 0.75
-         * @param hash     hash function for the key type, default is @code wlp::Hasher @endcode
-         * @param equal    equality function for the key type, default is @code wlp::Equals @endcode
-         */
         explicit OpenHashMap(
                 size_type n = 12,
                 percent_type max_load = 75)
-                : m_hash(Hasher()),
-                  m_equal(Equals()),
-                  m_num_elements(0),
-                  m_capacity(n),
-                  m_max_load(max_load) {
-            init_buckets(n);
-            if (max_load > 100) {
-                m_max_load = 100;
-            }
+                : m_table(n, max_load) {
         }
 
-        /**
-         * Copy constructor is deleted to prevent
-         * copying of complex structures.
-         */
         OpenHashMap(const map_type &) = delete;
 
-        /**
-         * Move constructor transfers resources from
-         * rvalue hash map into this hash map.
-         * @param map map from which to transfer
-         */
-        OpenHashMap(map_type &&map) :
-                m_hash(move(map.m_hash)),
-                m_equal(move(map.m_equal)),
-                m_buckets(move(map.m_buckets)),
-                m_num_elements(move(map.m_num_elements)),
-                m_capacity(move(map.m_capacity)),
-                m_max_load(move(map.m_max_load)) {
-            map.m_num_elements = 0;
-            map.m_capacity = 0;
-            map.m_buckets = nullptr;
+        OpenHashMap(map_type &&map)
+                : m_table(move(map.m_table)) {
         }
 
-        /**
-         * Destroy the hash map, freeing allocated nodes and
-         * memory allocated for the array.
-         */
-        ~OpenHashMap();
-
-    private:
-        /**
-         * Function called when creating the hash map. This function
-         * will allocate memory for the backing array and initialize each
-         * element to nullptr.
-         * @param n the size of the backing array
-         */
-        void init_buckets(size_type n);
-
-        /**
-         * Obtain the bucket index in an array with the specified
-         * number of maximum elements.
-         * @param key          the key to hash
-         * @param max_elements the maximum number of buckets
-         * @return an index i such that 0 <= i < max_elements
-         */
-        size_type bucket_index(const key_type &key, size_type max_elements) const {
-            return m_hash(key) % max_elements;
-        }
-
-        /**
-         * Obtain the bucket index of a key in the backing array.
-         * @param key the key to hash
-         * @return an index i such that 0 <= i < m_max_elements
-         */
-        size_type hash(const key_type &key) const {
-            return m_hash(key) % m_capacity;
-        }
-
-        /**
-         * Resize and rehash the hash map if the current load factor
-         * exceeds or equals the maximum load factor. This function
-         * will double the size of the backing array, allocating a new
-         * array, and fully deallocating the previous array.
-         *
-         * @pre this function will create a new array allocator, however
-         *      the same node allocator will be used, which means that
-         *      the node allocator will start drawing from heap memory
-         *      if the number of elements exceeds the initial max elements
-         */
-        void ensure_capacity();
-
-    public:
-        /**
-         * @return the current number of elements that have been
-         * inserted into the map
-         */
         size_type size() const {
-            return m_num_elements;
+            return m_table.size();
         }
 
-        /**
-         * @return the current size of the backing array
-         */
         size_type capacity() const {
-            return m_capacity;
+            return m_table.capacity();
         }
 
-        /**
-         * @return the maximum load before before rehash
-         */
         percent_type max_load() const {
-            return m_max_load;
+            return m_table.max_load();
         }
 
-        /**
-         * @return true if the map is empty
-         */
         bool empty() const {
-            return m_num_elements == 0;
+            return m_table.empty();
         }
 
-        /**
-         * Obtain an iterator to the first element in the hash map.
-         * Returns pass-the-end iterator if there are no elements
-         * in the hash map.
-         * @return iterator the first element
-         */
+        const table_type *get_backing_table() const {
+            return &m_table;
+        }
+
         iterator begin() {
-            if (m_num_elements == 0) {
-                return end();
-            }
-            for (size_type i = 0; i < m_capacity; ++i) {
-                if (m_buckets[i]) {
-                    return iterator(m_buckets[i], this);
-                }
-            }
-            return end();
+            return m_table.begin();
         }
 
-        /**
-         * @return a pass-the-end iterator for this map
-         */
-        iterator end() {
-            return iterator(nullptr, this);
-        }
-
-        /**
-         * @see OpenHashMap<Key, Val, Hasher, Equals>::begin()
-         * @return a constant iterator to the first element
-         */
         const_iterator begin() const {
-            if (m_num_elements == 0) {
-                return end();
-            }
-            for (size_type i = 0; i < m_capacity; ++i) {
-                if (m_buckets[i]) {
-                    return const_iterator(m_buckets[i], this);
-                }
-            }
-            return end();
+            return m_table.begin();
         }
 
-        /**
-         * @see OpenHashMap<Key, Val, Hasher, Equals>::end()
-         * @return a constant pass-the-end iterator
-         */
+        iterator end() {
+            return m_table.end();
+        }
+
         const_iterator end() const {
-            return const_iterator(nullptr, this);
+            return m_table.end();
         }
 
-        /**
-         * Erase all elements in the map, deallocating them
-         * and resetting the element count to zero.
-         */
-        void clear() noexcept;
+        void clear() noexcept {
+            m_table.clear();
+        }
 
-        /**
-         * Attempt to insert an element into the map.
-         * Insertion is prevented if there already exists
-         * an element with the provided key
-         *
-         * @param key inserted element key
-         * @param val inserted element value
-         * @return a pair consisting of an iterator pointing to the
-         * inserted element or the element that prevented insertion
-         * and a bool indicating whether insertion occurred
-         */
         template<typename K, typename V>
-        Pair<iterator, bool> insert(K &&key, V &&val);
+        Pair<iterator, bool> insert(K &&key, V &&val) {
+            return m_table.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
+        };
 
-        /**
-         * Attempt to insert an element into the map.
-         * If an element with the same key already exists,
-         * override the value mapped to by the provided key.
-         *
-         * @param key inserted element key
-         * @param val inserted element value
-         * @return a pair consisting of an iterator pointing to the
-         * inserted element or the assigned element, and a bool
-         * indicating whether insertion occurred
-         */
         template<typename K, typename V>
-        Pair<iterator, bool> insert_or_assign(K &&key, V &&val);
+        Pair<iterator, bool> insert_or_assign(K &&key, V &&val) {
+            Pair<iterator, bool> result = m_table.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
+            if (!result.m_second) {
+                *result.m_first = forward<V>(val);
+            }
+            return result;
+        };
 
-        /**
-         * Erase the element from the map pointed to by the provided
-         * iterator. Be aware that erasure operations on an openly
-         * addressed hash map will trigger a rehash and invalidate
-         * all iterators other than the return value.
-         *
-         * @param pos iterator pointing to the element to erase
-         * @return iterator to the next element in the map or end
-         */
-        iterator erase(const iterator &pos);
+        iterator erase(const iterator &pos) {
+            iterator tmp = pos;
+            ++tmp;
+            m_table.erase(pos);
+            return tmp;
+        }
 
-        /**
-         * Erase the element from the map with the provided key, if such
-         * an element exists. Be aware that if erasure if performed, the
-         * hash map will undergo a rehash.
-         *
-         * @pre If frequency use of erase operations is needed, one is
-         *      recommended to use @code ChainHashMap @encode or a
-         *      tree-based implementation.
-         *
-         * @param key the key whose corresponding element to erase
-         * @return true if an element was erased
-         */
-        bool erase(const key_type &key);
+        bool erase(const key_type &key) {
+            return m_table.erase(key) > 0;
+        }
 
-        /**
-         * Returns the value corresponding to a provided key.
-         *
-         * @param key the key for which to find the value
-         * @return the value mapped to by the key
-         * @throws KeyException if the key does not map to a value
-         */
         val_type &at(const key_type &key) {
-            return *find(key);
+            return *m_table.find(key);
         }
 
-        /**
-         * @see OpenHashMap<Key, Val, Hasher, Equals>::at()
-         * @param key key for which to find the value
-         * @return the mapped value
-         * @throws KeyException if the key does not exist
-         */
         const val_type &at(const key_type &key) const {
-            return *find(key);
+            return *m_table.find(key);
         }
 
-        /**
-         * @param key key for which to check existence of a value
-         * @return true if the key maps to a value
-         */
-        bool contains(const key_type &key) const;
+        bool contains(const key_type &key) const {
+            return m_table.find(key) != m_table.end();
+        }
 
-        /**
-         * Return an iterator to the map element corresponding
-         * to the provided key, or pass-the-end if the key does
-         * not map to any value in the map.
-         *
-         * @param key the key to map
-         * @return an iterator to the element mapped by the key
-         */
-        iterator find(const key_type &key);
+        iterator find(const key_type &key) {
+            return m_table.find(key);
+        }
 
-        /**
-         * @see OpenHashMap<Key, Val, Hasher, Equals>::find()
-         * @param key the key to map
-         * @return a const iterator to the element mapped by the key
-         */
-        const_iterator find(const key_type &key) const;
+        const_iterator find(const key_type &key) const {
+            return m_table.find(key);
+        }
 
-        /**
-         * Access an element in the hash map by the given key.
-         * If the key does not map to any value in the map,
-         * then a new value is created and inserted using the default
-         * constructor.
-         *
-         * @param key the key whose value to access
-         * @return a reference to the mapped value
-         */
         template<typename K>
-        val_type &operator[](K &&key);
+        val_type &operator[](K &&key) {
+            Pair<iterator, bool> result = m_table.insert_unique(make_tuple(forward<K>(key), val_type()));
+            return *result.m_first;
+        }
 
-        /**
-         * Copy assignment operators are disabled.
-         *
-         * @return hash map reference
-         */
         map_type &operator=(const map_type &) = delete;
 
-        /**
-         * Move assignment operator. Assigned hash map
-         * will have its resources transferred into this
-         * hash map. Existing resources will be released.
-         *
-         * @param map map to move
-         * @return reference to this map
-         */
-        map_type &operator=(map_type &&map);
-    };
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    void OpenHashMap<Key, Val, Hasher, Equals>::init_buckets(OpenHashMap<Key, Val, Hasher, Equals>::size_type n) {
-        m_buckets = malloc<node_type *[]>(n);
-        for (size_type i = 0; i < n; ++i) {
-            m_buckets[i] = nullptr;
-        }
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    void OpenHashMap<Key, Val, Hasher, Equals>::ensure_capacity() {
-        if (m_num_elements * 100 < m_max_load * m_capacity) {
-            return;
-        }
-        size_type new_capacity = static_cast<size_type>(m_capacity * 2);
-        node_type **new_buckets = malloc<node_type *[]>(new_capacity);
-        for (size_type i = 0; i < new_capacity; ++i) {
-            new_buckets[i] = nullptr;
-        }
-        for (size_type i = 0; i < m_capacity; ++i) {
-            if (!m_buckets[i]) {
-                continue;
-            }
-            node_type *node = m_buckets[i];
-            size_type k = bucket_index(node->m_key, new_capacity);
-            while (new_buckets[k]) {
-                if (++k >= new_capacity) {
-                    k = 0;
-                }
-            }
-            new_buckets[k] = node;
-        }
-        free<node_type *>(m_buckets);
-        m_buckets = new_buckets;
-        m_capacity = new_capacity;
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    void OpenHashMap<Key, Val, Hasher, Equals>::clear() noexcept {
-        for (size_type i = 0; i < m_capacity; ++i) {
-            if (m_buckets[i]) {
-                free<node_type>(m_buckets[i]);
-                m_buckets[i] = nullptr;
-            }
-        }
-        m_num_elements = 0;
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    template<typename K, typename V>
-    Pair<typename OpenHashMap<Key, Val, Hasher, Equals>::iterator, bool>
-    OpenHashMap<Key, Val, Hasher, Equals>::insert(K &&key, V &&val) {
-        ensure_capacity();
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (m_buckets[i]) {
-            return Pair<iterator, bool>(iterator(m_buckets[i], this), false);
-        } else {
-            ++m_num_elements;
-            node_type *node = malloc<node_type>();
-            node->m_key = forward<K>(key);
-            node->m_val = forward<V>(val);
-            m_buckets[i] = node;
-            return Pair<iterator, bool>(iterator(node, this), true);
+        map_type &operator=(map_type &&map) {
+            m_table = move(map.m_table);
+            return *this;
         }
     };
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    template<typename K, typename V>
-    Pair<typename OpenHashMap<Key, Val, Hasher, Equals>::iterator, bool>
-    OpenHashMap<Key, Val, Hasher, Equals>::insert_or_assign(K &&key, V &&val) {
-        ensure_capacity();
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (m_buckets[i]) {
-            m_buckets[i]->m_val = forward<V>(val);
-            return Pair<iterator, bool>(iterator(m_buckets[i], this), false);
-        } else {
-            ++m_num_elements;
-            node_type *node = malloc<node_type>();
-            node->m_key = forward<K>(key);
-            node->m_val = forward<V>(val);
-            m_buckets[i] = node;
-            return Pair<iterator, bool>(iterator(node, this), true);
-        }
-    };
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    typename OpenHashMap<Key, Val, Hasher, Equals>::iterator
-    OpenHashMap<Key, Val, Hasher, Equals>::erase(const iterator &pos) {
-        const node_type *cur_node = pos.m_current;
-        if (!cur_node || pos.m_hash_map != this) {
-            return end();
-        }
-        size_type i = hash(cur_node->m_key);
-        while (m_buckets[i] && !m_equal(cur_node->m_key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (!m_buckets[i]) {
-            return end();
-        }
-        --m_num_elements;
-        free<node_type>(m_buckets[i]);
-        m_buckets[i] = nullptr;
-        while (++i < m_capacity && !m_buckets[i]) {}
-        node_type *next_node = i >= m_capacity ? nullptr : m_buckets[i];
-        node_type **new_buckets = malloc<node_type *[]>(m_capacity);
-        for (size_type k = 0; k < m_capacity; k++) {
-            new_buckets[k] = nullptr;
-        }
-        for (size_type k = 0; k < m_capacity; k++) {
-            if (!m_buckets[k]) {
-                continue;
-            }
-            node_type *node = m_buckets[k];
-            size_type j = hash(node->m_key);
-            while (new_buckets[j]) {
-                if (++j >= m_capacity) {
-                    j = 0;
-                }
-            }
-            new_buckets[j] = node;
-        }
-        free<node_type *>(m_buckets);
-        m_buckets = new_buckets;
-        return iterator(next_node, this);
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    bool OpenHashMap<Key, Val, Hasher, Equals>::erase(const key_type &key) {
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (!m_buckets[i]) {
-            return false;
-        }
-        --m_num_elements;
-        free<node_type>(m_buckets[i]);
-        m_buckets[i] = nullptr;
-        node_type **new_buckets = malloc<node_type *[]>(m_capacity);
-        for (size_type k = 0; k < m_capacity; k++) {
-            new_buckets[k] = nullptr;
-        }
-        for (size_type k = 0; k < m_capacity; k++) {
-            if (!m_buckets[k]) {
-                continue;
-            }
-            node_type *node = m_buckets[k];
-            size_type j = hash(node->m_key);
-            while (new_buckets[j]) {
-                if (++j >= m_capacity) {
-                    j = 0;
-                }
-            }
-            new_buckets[j] = node;
-        }
-        free<node_type *>(m_buckets);
-        m_buckets = new_buckets;
-        return true;
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    bool OpenHashMap<Key, Val, Hasher, Equals>::contains(const key_type &key) const {
-        size_type i = hash(key);
-        while (m_buckets[i]) {
-            if (m_equal(key, m_buckets[i]->m_key)) {
-                return true;
-            }
-            if (++i > +m_capacity) {
-                i = 0;
-            }
-        }
-        return false;
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    template<typename K>
-    typename OpenHashMap<Key, Val, Hasher, Equals>::val_type &
-    OpenHashMap<Key, Val, Hasher, Equals>::operator[](K &&key) {
-        ensure_capacity();
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (m_buckets[i]) {
-            return m_buckets[i]->m_val;
-        } else {
-            ++m_num_elements;
-            node_type *node = malloc<node_type>();
-            node->m_key = forward<K>(key);
-            node->m_val = val_type();
-            m_buckets[i] = node;
-            return node->m_val;
-        }
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    inline typename OpenHashMap<Key, Val, Hasher, Equals>::iterator
-    OpenHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) {
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (m_buckets[i]) {
-            return iterator(m_buckets[i], this);
-        } else {
-            return end();
-        }
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    inline typename OpenHashMap<Key, Val, Hasher, Equals>::const_iterator
-    OpenHashMap<Key, Val, Hasher, Equals>::find(const key_type &key) const {
-        size_type i = hash(key);
-        while (m_buckets[i] && !m_equal(key, m_buckets[i]->m_key)) {
-            if (++i >= m_capacity) {
-                i = 0;
-            }
-        }
-        if (m_buckets[i]) {
-            return const_iterator(m_buckets[i], this);
-        } else {
-            return end();
-        }
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    OpenHashMap<Key, Val, Hasher, Equals>::~OpenHashMap() {
-        if (!m_buckets) {
-            return;
-        }
-        for (size_type i = 0; i < m_capacity; ++i) {
-            if (m_buckets[i]) {
-                free<node_type>(m_buckets[i]);
-                m_buckets[i] = nullptr;
-            }
-        }
-        free<node_type *>(m_buckets);
-        m_buckets = nullptr;
-    }
-
-    template<typename Key, typename Val, typename Hasher, typename Equals>
-    OpenHashMap<Key, Val, Hasher, Equals> &
-    OpenHashMap<Key, Val, Hasher, Equals>::operator=(OpenHashMap<Key, Val, Hasher, Equals> &&map) {
-        clear();
-        free<node_type *>(m_buckets);
-        m_capacity = move(map.m_capacity);
-        m_max_load = move(map.m_max_load);
-        m_num_elements = move(map.m_num_elements);
-        m_buckets = move(map.m_buckets);
-        map.m_capacity = 0;
-        map.m_num_elements = 0;
-        map.m_buckets = nullptr;
-        return *this;
-    }
-
-    template<typename Key, typename Val, typename Ref, typename Ptr, typename Hasher, typename Equals>
-    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals> &
-    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++() {
-        size_type i = m_hash_map->hash(m_current->m_key);
-        while (m_hash_map->m_buckets[i] && !m_hash_map->m_equal(m_current->m_key, m_hash_map->m_buckets[i]->m_key)) {
-            if (++i >= m_hash_map->m_capacity) {
-                i = 0;
-            }
-        }
-        while (++i < m_hash_map->m_capacity && !m_hash_map->m_buckets[i]) {}
-        if (i == m_hash_map->m_capacity) {
-            m_current = nullptr;
-        } else {
-            m_current = m_hash_map->m_buckets[i];
-        }
-        return *this;
-    }
-
-    template<typename Key, typename Val, typename Ref, typename Ptr, typename Hasher, typename Equals>
-    inline OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>
-    OpenHashMapIterator<Key, Val, Ref, Ptr, Hasher, Equals>::operator++(int) {
-        self_type tmp = *this;
-        ++*this;
-        return tmp;
-    }
 
 }
 

--- a/lib/wlib/stl/OpenSet.h
+++ b/lib/wlib/stl/OpenSet.h
@@ -15,7 +15,11 @@
 
 #include "Equal.h"
 #include "Hash.h"
-#include "OpenMap.h"
+#include "OpenTable.h"
+#include "Pair.h"
+#include "Table.h"
+
+#include "../utility/Utility.h"
 
 namespace wlp {
 
@@ -23,215 +27,117 @@ namespace wlp {
      * An open hash set is created using a backing hash map,
      * and all available functions are a subset of the functions
      * of the hash map. The set contains unique elements.
+     *
      * @tparam Key   the unique element type
      * @tparam Hash  the hash function of the stored elements
      * @tparam Equal test for equality function of the stored elements
      */
     template<class Key,
-            class Hash = Hash<Key, uint16_t>,
-            class Equal = Equal<Key>>
+            class Hasher = Hash <Key, uint16_t>,
+            class Equals = Equal <Key>>
     class OpenHashSet {
     public:
-        typedef OpenHashSet<Key, Hash, Equal> set_type;
-        typedef OpenHashMap<Key, Key, Hash, Equal> table_type;
-        typedef typename OpenHashMap<Key, Key, Hash, Equal>::iterator iterator;
-        typedef typename OpenHashMap<Key, Key, Hash, Equal>::const_iterator const_iterator;
+        typedef OpenHashSet<Key, Hasher, Equals> set_type;
+        typedef OpenHashTable<Key,
+            Key, Key,
+            SetGetKey<Key>, SetGetVal<Key>,
+            Hasher, Equals
+        > table_type;
+        typedef typename table_type::iterator iterator;
+        typedef typename table_type::const_iterator const_iterator;
         typedef typename table_type::size_type size_type;
         typedef typename table_type::percent_type percent_type;
-        typedef typename table_type::key_type key_type;
+
+        typedef Key key_type;
 
     private:
-        /**
-         * The backing hash map.
-         */
-        table_type m_hash_map;
+        table_type m_table;
 
     public:
-        /**
-         * Constructor creates a new hash map, and instantiates
-         * the backing hash map.
-         *
-         * @see OpenHashMap
-         * @param n        the initial size of the backing array
-         * @param max_load the maximum load factor before rehash
-         */
         explicit OpenHashSet(
                 size_type n = 12,
-                percent_type max_load = 75) :
-                m_hash_map(n, max_load) {
+                percent_type max_load = 75)
+                : m_table(n, max_load) {
         }
 
-        /**
-         * Disable copy constructor.
-         */
         OpenHashSet(const set_type &) = delete;
 
-        /**
-         * Move constructor.
-         *
-         * @param set hash set to move
-         */
         OpenHashSet(set_type &&set)
-                : m_hash_map(move(set.m_hash_map)) {
+                : m_table(move(set.m_table)) {
         }
 
-        /**
-         * @return the current number of elements in the set
-         */
         size_type size() const {
-            return m_hash_map.size();
+            return m_table.size();
         }
 
-        /**
-         * @return the size of the backing array
-         */
         size_type capacity() const {
-            return m_hash_map.capacity();
+            return m_table.capacity();
         }
 
-        /**
-         * @return the maximum load factor
-         */
         percent_type max_load() const {
-            return m_hash_map.max_load();
+            return m_table.max_load();
         }
 
-        /**
-         * @return whether the hash map is empty
-         */
         bool empty() const {
-            return m_hash_map.empty();
+            return m_table.empty();
         }
 
-        /**
-         * @return a pointer to the backing hash map
-         */
-        const table_type *get_backing_hash_map() const {
-            return &m_hash_map;
+        const table_type *get_backing_table() const {
+            return &m_table;
         }
 
-        /**
-         * An iterator instance to the beginning of the hash set.
-         * The iterator order of the set is not guaranteed to
-         * be in any particular order.
-         * @return iterator to the first element, or @code end @endcode
-         * if the set is empty
-         */
         iterator begin() {
-            return m_hash_map.begin();
+            return m_table.begin();
         }
 
-        /**
-         * A pass-the-end iterator instance. This iterator means
-         * that an iterator has read past the end of the set
-         * and has become invalid.
-         * @return a pass-the-end iterator
-         */
-        iterator end() {
-            return m_hash_map.end();
-        }
-
-        /**
-         * @return a constant iterator to the first element
-         */
         const_iterator begin() const {
-            return m_hash_map.begin();
+            return m_table.begin();
         }
 
-        /**
-         * @return a constant pass-the-end iterator
-         */
+        iterator end() {
+            return m_table.end();
+        }
+
         const_iterator end() const {
-            return m_hash_map.end();
+            return m_table.end();
         }
 
-        /**
-         * Empty the elements in the set, such that its
-         * size is now zero.
-         */
         void clear() noexcept {
-            m_hash_map.clear();
+            m_table.clear();
         }
 
-        /**
-         * Insert an element into the set. This function
-         * returns a pair consistent of the iterator to the
-         * element that was inserted or to the element that
-         * prevented insertion. The second boolean value indicates
-         * whether insertion took place.
-         * @param key the element to insert
-         * @return a pair of an iterator and boolean
-         */
         template<typename K>
         Pair<iterator, bool> insert(K &&key) {
-            return m_hash_map.insert(forward<K>(key), forward<K>(key));
+            return m_table.insert_unique(key);
         };
 
-        /**
-         * Check if an element is in the set.
-         * @param key element whose existence to check
-         * @return true if the element is contained in the set
-         */
         bool contains(const key_type &key) const {
-            return m_hash_map.contains(key);
+            return m_table.find(key) != m_table.end();
         }
 
-        /**
-         * Obtain an iterator to an element in the set.
-         * @param key the element to find
-         * @return iterator to the element or pass-the-end
-         * if the element is not in the set
-         */
         iterator find(const key_type &key) {
-            return m_hash_map.find(key);
+            return m_table.find(key);
         }
 
-        /**
-         * Obtain a const iterator to an element in the set
-         * @param key the element to find
-         * @return const iterator to the element or pass-the-end
-         * if the element is not in the set
-         */
         const_iterator find(const key_type &key) const {
-            return m_hash_map.find(key);
+            return m_table.find(key);
         }
 
-        /**
-         * Erase the element in the set pointed to by
-         * the iterator.
-         *
-         * @param pos iterator whose element to erase
-         * @return iterator to the next element in the set
-         */
         iterator erase(const iterator &pos) {
-            return m_hash_map.erase(pos);
+            iterator tmp = pos;
+            ++tmp;
+            m_table.erase(pos);
+            return tmp;
         }
 
-        /**
-         * Remove an element from the set.
-         *
-         * @param key the element to remove
-         * @return true if removal occured
-         */
         bool erase(const key_type &key) {
-            return m_hash_map.erase(key);
+            return m_table.erase(key) > 0;
         }
 
-        /**
-         * Disable copy assignment.
-         *
-         * @return reference to this set
-         */
         set_type &operator=(const set_type &) = delete;
 
-        /**
-         * Move assignment operator.
-         *
-         * @param set hash set to move
-         * @return reference to this set
-         */
         set_type &operator=(set_type &&set) {
-            m_hash_map = move(set.m_hash_map);
+            m_table = move(set.m_table);
             return *this;
         }
     };

--- a/lib/wlib/stl/OpenTable.h
+++ b/lib/wlib/stl/OpenTable.h
@@ -1,0 +1,808 @@
+/**
+ * @file OpenMap.h
+ * @brief Hash map implementation.
+ *
+ * Hash map is implemented using open addressing and linear probing,
+ * based on the assumption that it will be used with good knowledge
+ * of the needed map size. The Hash Map provides the same basic
+ * functionality as std::unordered_map or std::map_type.
+ *
+ * @author Jeff Niu
+ * @date November 1, 2017
+ * @bug No known bugs
+ */
+
+#ifndef CORE_STL_HASH_TABLE_H
+#define CORE_STL_HASH_TABLE_H
+
+#include "Equal.h"
+#include "Hash.h"
+#include "Pair.h"
+
+#include "../memory/Memory.h"
+#include "../utility/Utility.h"
+#include "../exceptions/Exceptions.h"
+
+namespace wlp {
+
+    // Forward declaration of OpenHashTable
+    template<typename Element,
+            typename Key,
+            typename Val,
+            typename GetKey,
+            typename GetVal,
+            typename Hasher,
+            typename Equals>
+    class OpenHashTable;
+
+    /**
+     * Iterator class over the elements of a OpenHashTable. Specifically,
+     * this class iterates from start to end of the OpenHashTable's backing
+     * array, returning past-the-end afterwards.
+     *
+     * @tparam Element element type containing the value
+     * @tparam Val     value type
+     * @tparam Ref     reference type to value
+     * @tparam Ptr     pointer type to value
+     * @tparam GetVal  functor type to obtain value from element
+     */
+    template<typename Element,
+            typename Key,
+            typename Val,
+            typename Ref,
+            typename Ptr,
+            typename GetKey,
+            typename GetVal,
+            typename Hasher,
+            typename Equals>
+    struct OpenHashTableIterator {
+        typedef OpenHashTableIterator<Element, Key, Val, Ref, Ptr, GetKey, GetVal, Hasher, Equals> self_type;
+        typedef OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals> table_type;
+
+        typedef Element element_type;
+        typedef Val val_type;
+        typedef Ref reference;
+        typedef Ptr pointer;
+        typedef GetKey get_key;
+        typedef GetVal get_value;
+
+        typedef wlp::size_type size_type;
+
+        /**
+         * Pointer to the node referenced by this iterator.
+         */
+        element_type *m_current;
+        /**
+         * Pointer to the hash map to which this iterator belongs.
+         */
+        const table_type *m_table;
+        /**
+         * Functor used to obtain element key.
+         */
+        get_key m_get_key{};
+        /**
+         * Functor used to obtain element value.
+         */
+        get_value m_get_value{};
+
+        /**
+         * Default constructor.
+         */
+        OpenHashTableIterator()
+                : m_current(nullptr),
+                  m_table(nullptr) {
+        }
+
+        /**
+         * Create an iterator to a OpenHashTable node.
+         * @param node hash map node
+         * @param map  parent hash map
+         */
+        OpenHashTableIterator(element_type *node, const table_type *hash_map)
+                : m_current(node),
+                  m_table(hash_map) {
+        }
+
+        /**
+         * Copy constructor for const.
+         * @param it iterator to copy
+         */
+        OpenHashTableIterator(const self_type &it)
+                : m_current(it.m_current),
+                  m_table(it.m_table) {
+        }
+
+        /**
+         * @return reference to the value of the node
+         * pointed to by the iterator
+         */
+        reference operator*() const {
+            if (m_current == nullptr) {
+                THROW(KEY_EXCEPTION("Accessing invalid iterator"))
+            }
+            return m_get_value(*m_current);
+        }
+
+        /**
+         * @return pointer to the value of the node
+         * pointed to by the iterator
+         */
+        pointer operator->() const {
+            return &(operator*());
+        }
+
+        /**
+         * Increment the iterator to the next available element in
+         * the OpenHashTable. If no such element exists, returns pass-the-end
+         * iterator. This is pre-fix unary operator.
+         * @return this iterator
+         */
+        self_type &operator++();
+
+        /**
+         * Post-fix unary operator.
+         * @return this iterator
+         */
+        self_type operator++(int);
+
+        /**
+         * Compare two iterators, equal of they point to the
+         * same node.
+         * @param it iterator to compare
+         * @return true if both point to the same node
+         */
+        bool operator==(const self_type &it) const {
+            return m_current == it.m_current;
+        }
+
+        /**
+         * Compare two iterators, unequal if they point to
+         * different nodes.
+         * @param it iterator to compare
+         * @return true if they point to different nodes
+         */
+        bool operator!=(const self_type &it) const {
+            return m_current != it.m_current;
+        }
+
+        /**
+         * Assignment operator copies pointers to node
+         * and hash map.
+         * @param it iterator to copy
+         * @return a reference to this iterator
+         */
+        self_type &operator=(const self_type &it) {
+            m_current = it.m_current;
+            m_table = it.m_table;
+            return *this;
+        }
+
+    };
+
+    /**
+     * Hash map implemented using open addressing and linear probing,
+     * in the spirit of std::unordered_map.
+     *
+     * @tparam Element element type containing the key and value
+     * @tparam Key     key type
+     * @tparam Val     value type
+     * @tparam GetKey  functor for obtaining key from element
+     * @tparam GetVal  functor for obtaining value from element
+     * @tparam Hasher  hash function functor
+     * @tparam Equals  key equality functor
+     */
+    template<typename Element,
+            typename Key,
+            typename Val,
+            typename GetKey,
+            typename GetVal,
+            typename Hasher = Hash <Key, uint16_t>,
+            typename Equals = Equal <Key>>
+    class OpenHashTable {
+    public:
+        typedef OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals> map_type;
+        typedef OpenHashTableIterator<
+                Element, Key, 
+                Val, Val &, Val *, 
+                GetKey, GetVal, 
+                Hasher, Equals
+        > iterator;
+        typedef OpenHashTableIterator<
+                Element, Key, Val, 
+                const Val &, const Val *,
+                GetKey, GetVal,
+                Hasher, Equals
+        > const_iterator;
+
+        typedef Element element_type;
+        typedef Key key_type;
+        typedef Val val_type;
+        typedef GetKey get_key;
+        typedef GetVal get_value;
+
+        typedef wlp::size_type size_type;
+        typedef uint8_t percent_type;
+
+        typedef Hasher hash_function;
+        typedef Equals key_equals;
+
+        friend struct OpenHashTableIterator<
+                Element, Key,
+                Val, Val &, Val *,
+                GetKey, GetVal,
+                Hasher, Equals>;
+        friend struct OpenHashTableIterator<
+                Element, Key, Val,
+                const Val &, const Val *,
+                GetKey, GetVal,
+                Hasher, Equals>;
+
+    private:
+        /**
+         * Class hash function instance. Used to hash
+         * element keys.
+         */
+        hash_function m_hash;
+        /**
+         * Class key equality function. Used to test
+         * equality of element keys.
+         */
+        key_equals m_equal;
+        /**
+         * Functor to obtain key from element.
+         */
+        get_key m_get_key{};
+
+        /**
+         * Hash map backing array.
+         */
+        element_type **m_buckets;
+
+        /**
+         * The current number of elements that have been inserted
+         * into the map.
+         */
+        size_type m_num_elements;
+        /**
+         * The size of the backing array.
+         */
+        size_type m_capacity;
+        /**
+         * The load factor in integer percent
+         * before rehashing occurs. This number
+         * cannot be larger than 100.
+         */
+        percent_type m_max_load;
+
+    public:
+        /**
+         * Create and initialize an empty hash map. The hash map uses
+         * The hash map is implemented with open addressing and linear probing.
+         *
+         * @pre the hash map requires definition of an initial bucket array size
+         *      and a maximum load factor before rehashing
+         *
+         * @param n        initial size of the bucket list; each bucket is initialized to nullptr
+         * @param max_load an integer value denoting the max percent load factory, e.g. 75 = 0.75
+         * @param hash     hash function for the key type, default is @code wlp::Hasher @endcode
+         * @param equal    equality function for the key type, default is @code wlp::Equals @endcode
+         */
+        explicit OpenHashTable(
+                size_type n = 12,
+                percent_type max_load = 75)
+                : m_hash(),
+                  m_equal(),
+                  m_num_elements(0),
+                  m_capacity(n),
+                  m_max_load(max_load) {
+            init_buckets(n);
+            if (max_load > 100) {
+                m_max_load = 100;
+            }
+        }
+
+        /**
+         * Copy constructor is deleted to prevent
+         * copying of complex structures.
+         */
+        OpenHashTable(const map_type &) = delete;
+
+        /**
+         * Move constructor transfers resources from
+         * rvalue hash map into this hash map.
+         * @param map map from which to transfer
+         */
+        OpenHashTable(map_type &&map) :
+                m_hash(move(map.m_hash)),
+                m_equal(move(map.m_equal)),
+                m_buckets(move(map.m_buckets)),
+                m_num_elements(move(map.m_num_elements)),
+                m_capacity(move(map.m_capacity)),
+                m_max_load(move(map.m_max_load)) {
+            map.m_num_elements = 0;
+            map.m_capacity = 0;
+            map.m_buckets = nullptr;
+        }
+
+        /**
+         * Destroy the hash map, freeing allocated nodes and
+         * memory allocated for the array.
+         */
+        ~OpenHashTable();
+
+    private:
+        /**
+         * Function called when creating the hash map. This function
+         * will allocate memory for the backing array and initialize each
+         * element to nullptr.
+         * @param n the size of the backing array
+         */
+        void init_buckets(size_type n);
+
+        /**
+         * Obtain the bucket index in an array with the specified
+         * number of maximum elements.
+         * @param key          the key to hash
+         * @param max_elements the maximum number of buckets
+         * @return an index i such that 0 <= i < max_elements
+         */
+        size_type bucket_index(const key_type &key, size_type max_elements) const {
+            return m_hash(key) % max_elements;
+        }
+
+        /**
+         * Obtain the bucket index of a key in the backing array.
+         * @param key the key to hash
+         * @return an index i such that 0 <= i < m_max_elements
+         */
+        size_type hash(const key_type &key) const {
+            return m_hash(key) % m_capacity;
+        }
+
+        /**
+         * Resize and rehash the hash map if the current load factor
+         * exceeds or equals the maximum load factor. This function
+         * will double the size of the backing array, allocating a new
+         * array, and fully deallocating the previous array.
+         *
+         * @pre this function will create a new array allocator, however
+         *      the same node allocator will be used, which means that
+         *      the node allocator will start drawing from heap memory
+         *      if the number of elements exceeds the initial max elements
+         */
+        void ensure_capacity();
+
+    public:
+        /**
+         * Obtain an iterator to the first element in the hash map.
+         * Returns pass-the-end iterator if there are no elements
+         * in the hash map.
+         * @return iterator the first element
+         */
+        iterator begin() {
+            if (m_num_elements == 0) {
+                return end();
+            }
+            for (size_type i = 0; i < m_capacity; ++i) {
+                if (m_buckets[i]) {
+                    return iterator(m_buckets[i], this);
+                }
+            }
+            return end();
+        }
+
+        /**
+         * @see OpenHashTable<Key, Val, Hasher, Equals>::begin()
+         * @return a constant iterator to the first element
+         */
+        const_iterator begin() const {
+            if (m_num_elements == 0) {
+                return end();
+            }
+            for (size_type i = 0; i < m_capacity; ++i) {
+                if (m_buckets[i]) {
+                    return const_iterator(m_buckets[i], this);
+                }
+            }
+            return end();
+        }
+
+        /**
+         * @return a pass-the-end iterator for this map
+         */
+        iterator end() {
+            return iterator(nullptr, this);
+        }
+
+        /**
+         * @see OpenHashTable<Key, Val, Hasher, Equals>::end()
+         * @return a constant pass-the-end iterator
+         */
+        const_iterator end() const {
+            return const_iterator(nullptr, this);
+        }
+
+        /**
+         * @return true if the map is empty
+         */
+        bool empty() const {
+            return m_num_elements == 0;
+        }
+
+        /**
+         * @return the current number of elements that have been
+         * inserted into the map
+         */
+        size_type size() const {
+            return m_num_elements;
+        }
+
+        /**
+         * @return the current size of the backing array
+         */
+        size_type capacity() const {
+            return m_capacity;
+        }
+
+        /**
+         * @return the maximum load before before rehash
+         */
+        percent_type max_load() const {
+            return m_max_load;
+        }
+
+        /**
+         * Erase all elements in the map, deallocating them
+         * and resetting the element count to zero.
+         */
+        void clear() noexcept;
+
+        /**
+         * Attempt to insert an element into the map.
+         * Insertion is prevented if there already exists
+         * an element with the provided key
+         *
+         * @param key inserted element key
+         * @param val inserted element value
+         * @return a pair consisting of an iterator pointing to the
+         * inserted element or the element that prevented insertion
+         * and a bool indicating whether insertion occurred
+         */
+        template<typename E>
+        Pair<iterator, bool> insert_unique(E &&element);
+
+        /**
+         * Erase the element from the map pointed to by the provided
+         * iterator. Be aware that erasure operations on an openly
+         * addressed hash map will trigger a rehash and invalidate
+         * all iterators other than the return value.
+         *
+         * @param pos iterator pointing to the element to erase
+         * @return iterator to the next element in the map or end
+         */
+        void erase(const iterator &pos);
+
+        /**
+         * Erase the element from the map with the provided key, if such
+         * an element exists. Be aware that if erasure if performed, the
+         * hash map will undergo a rehash.
+         *
+         * @pre If frequency use of erase operations is needed, one is
+         *      recommended to use @code ChainHashMap @encode or a
+         *      tree-based implementation.
+         *
+         * @param key the key whose corresponding element to erase
+         * @return true if an element was erased
+         */
+        size_type erase(const key_type &key);
+
+        /**
+         * Return an iterator to the map element corresponding
+         * to the provided key, or pass-the-end if the key does
+         * not map to any value in the map.
+         *
+         * @param key the key to map
+         * @return an iterator to the element mapped by the key
+         */
+        iterator find(const key_type &key);
+
+        /**
+         * @see OpenHashTable<Key, Val, Hasher, Equals>::find()
+         * @param key the key to map
+         * @return a const iterator to the element mapped by the key
+         */
+        const_iterator find(const key_type &key) const;
+
+        /**
+         * Copy assignment operators are disabled.
+         *
+         * @return hash map reference
+         */
+        map_type &operator=(const map_type &) = delete;
+
+        /**
+         * Move assignment operator. Assigned hash map
+         * will have its resources transferred into this
+         * hash map. Existing resources will be released.
+         *
+         * @param map map to move
+         * @return reference to this map
+         */
+        map_type &operator=(map_type &&map);
+    };
+
+    template<typename Element, typename Key, typename Val, 
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    void OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::init_buckets(OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>::size_type n) {
+        m_buckets = malloc<element_type *[]>(n);
+        for (size_type i = 0; i < n; ++i) {
+            m_buckets[i] = nullptr;
+        }
+    }
+
+    template<typename Element, typename Key, typename Val, 
+            typename GetKey, typename GetVal, 
+            typename Hasher, typename Equals>
+    void OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::ensure_capacity() {
+        if (m_num_elements * 100 < m_max_load * m_capacity) {
+            return;
+        }
+        size_type new_capacity = static_cast<size_type>(m_capacity * 2);
+        element_type **new_buckets = malloc<element_type *[]>(new_capacity);
+        for (size_type i = 0; i < new_capacity; ++i) {
+            new_buckets[i] = nullptr;
+        }
+        for (size_type i = 0; i < m_capacity; ++i) {
+            if (!m_buckets[i]) {
+                continue;
+            }
+            element_type *node = m_buckets[i];
+            size_type k = bucket_index(m_get_key(*node), new_capacity);
+            while (new_buckets[k]) {
+                if (++k >= new_capacity) {
+                    k = 0;
+                }
+            }
+            new_buckets[k] = node;
+        }
+        free<element_type *>(m_buckets);
+        m_buckets = new_buckets;
+        m_capacity = new_capacity;
+    }
+
+    template<typename Element, typename Key, typename Val, 
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    void OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::clear() noexcept {
+        for (size_type i = 0; i < m_capacity; ++i) {
+            if (m_buckets[i]) {
+                free<element_type>(m_buckets[i]);
+                m_buckets[i] = nullptr;
+            }
+        }
+        m_num_elements = 0;
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal, 
+            typename Hasher, typename Equals>
+    template<typename E>
+    Pair<typename OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>::iterator, bool>
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::insert_unique(E &&element) {
+        ensure_capacity();
+        size_type i = hash(m_get_key(element));
+        while (m_buckets[i] && !m_equal(m_get_key(element), m_get_key(*m_buckets[i]))) {
+            if (++i >= m_capacity) {
+                i = 0;
+            }
+        }
+        if (m_buckets[i]) {
+            return Pair<iterator, bool>(iterator(m_buckets[i], this), false);
+        } else {
+            ++m_num_elements;
+            element_type *node = malloc<element_type>();
+            *node = forward<E>(element);
+            m_buckets[i] = node;
+            return Pair<iterator, bool>(iterator(node, this), true);
+        }
+    };
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    void OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::erase(const iterator &pos) {
+        const element_type *cur_node = pos.m_current;
+        if (!cur_node) {
+            return;
+        }
+        size_type i = hash(m_get_key(*cur_node));
+        while (m_buckets[i] && !m_equal(m_get_key(*cur_node), m_get_key(*m_buckets[i]))) {
+            if (++i >= m_capacity) {
+                i = 0;
+            }
+        }
+        if (!m_buckets[i]) {
+            return;
+        }
+        --m_num_elements;
+        free<element_type>(m_buckets[i]);
+        m_buckets[i] = nullptr;
+        element_type **new_buckets = malloc<element_type *[]>(m_capacity);
+        for (size_type k = 0; k < m_capacity; k++) {
+            new_buckets[k] = nullptr;
+        }
+        for (size_type k = 0; k < m_capacity; k++) {
+            if (!m_buckets[k]) {
+                continue;
+            }
+            element_type *node = m_buckets[k];
+            size_type j = hash(m_get_key(*node));
+            while (new_buckets[j]) {
+                if (++j >= m_capacity) {
+                    j = 0;
+                }
+            }
+            new_buckets[j] = node;
+        }
+        free<element_type *>(m_buckets);
+        m_buckets = new_buckets;
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    size_type OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::erase(const key_type &key) {
+        size_type i = hash(key);
+        while (m_buckets[i] && !m_equal(key, m_get_key(*m_buckets[i]))) {
+            if (++i >= m_capacity) {
+                i = 0;
+            }
+        }
+        if (!m_buckets[i]) {
+            return 0;
+        }
+        --m_num_elements;
+        free<element_type>(m_buckets[i]);
+        m_buckets[i] = nullptr;
+        element_type **new_buckets = malloc<element_type *[]>(m_capacity);
+        for (size_type k = 0; k < m_capacity; k++) {
+            new_buckets[k] = nullptr;
+        }
+        for (size_type k = 0; k < m_capacity; k++) {
+            if (!m_buckets[k]) {
+                continue;
+            }
+            element_type *node = m_buckets[k];
+            size_type j = hash(m_get_key(*node));
+            while (new_buckets[j]) {
+                if (++j >= m_capacity) {
+                    j = 0;
+                }
+            }
+            new_buckets[j] = node;
+        }
+        free<element_type *>(m_buckets);
+        m_buckets = new_buckets;
+        return 1;
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    inline typename OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>::iterator
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::find(const key_type &key) {
+        size_type i = hash(key);
+        while (m_buckets[i] && !m_equal(key, m_get_key(*m_buckets[i]))) {
+            if (++i >= m_capacity) {
+                i = 0;
+            }
+        }
+        if (m_buckets[i]) {
+            return iterator(m_buckets[i], this);
+        } else {
+            return end();
+        }
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    inline typename OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>::const_iterator
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::find(const key_type &key) const {
+        size_type i = hash(key);
+        while (m_buckets[i] && !m_equal(key, m_get_key(*m_buckets[i]))) {
+            if (++i >= m_capacity) {
+                i = 0;
+            }
+        }
+        if (m_buckets[i]) {
+            return const_iterator(m_buckets[i], this);
+        } else {
+            return end();
+        }
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::~OpenHashTable() {
+        if (!m_buckets) {
+            return;
+        }
+        for (size_type i = 0; i < m_capacity; ++i) {
+            if (m_buckets[i]) {
+                free<element_type>(m_buckets[i]);
+                m_buckets[i] = nullptr;
+            }
+        }
+        free<element_type *>(m_buckets);
+        m_buckets = nullptr;
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals> &
+    OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals>
+    ::operator=(OpenHashTable<Element, Key, Val, GetKey, GetVal, Hasher, Equals> &&map) {
+        clear();
+        free<element_type *>(m_buckets);
+        m_capacity = move(map.m_capacity);
+        m_max_load = move(map.m_max_load);
+        m_num_elements = move(map.m_num_elements);
+        m_buckets = move(map.m_buckets);
+        map.m_capacity = 0;
+        map.m_num_elements = 0;
+        map.m_buckets = nullptr;
+        return *this;
+    }
+
+    template<typename Element, typename Key, typename Val, 
+            typename Ref, typename Ptr, 
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    OpenHashTableIterator<Element, Key, Val, Ref, Ptr, GetKey, GetVal, Hasher, Equals> &
+    OpenHashTableIterator<Element, Key, Val, Ref, Ptr, GetKey, GetVal, Hasher, Equals>
+    ::operator++() {
+        if (!m_current) {
+            return *this;
+        }
+        size_type i = m_table->hash(m_get_key(*m_current));
+        while (m_table->m_buckets[i] && !m_table->m_equal(m_get_key(*m_current), m_get_key(*m_table->m_buckets[i]))) {
+            if (++i >= m_table->m_capacity) {
+                i = 0;
+            }
+        }
+        while (++i < m_table->m_capacity && !m_table->m_buckets[i]) {}
+        if (i == m_table->m_capacity) {
+            m_current = nullptr;
+        } else {
+            m_current = m_table->m_buckets[i];
+        }
+        return *this;
+    }
+
+    template<typename Element, typename Key, typename Val,
+            typename Ref, typename Ptr,
+            typename GetKey, typename GetVal,
+            typename Hasher, typename Equals>
+    inline OpenHashTableIterator<Element, Key, Val, Ref, Ptr, GetKey, GetVal, Hasher, Equals>
+    OpenHashTableIterator<Element, Key, Val, Ref, Ptr, GetKey, GetVal, Hasher, Equals>::operator++(int) {
+        self_type tmp = *this;
+        ++*this;
+        return tmp;
+    }
+
+}
+
+#endif //CORE_STL_HASH_TABLE_H

--- a/lib/wlib/stl/RedBlackTree.h
+++ b/lib/wlib/stl/RedBlackTree.h
@@ -440,7 +440,7 @@ namespace wlp {
          * @param rightmost the right most node in the tree
          * @return a pointer to the node that can be deleted
          */
-        node_type *eraseRebalance(
+        node_type *erase_rebalance(
                 node_type *node,
                 node_type *&root,
                 node_type *&leftmost,
@@ -753,7 +753,7 @@ namespace wlp {
          * Move assignment operator. Resources in this tree
          * are freed and replaced by moving those from the
          * assigned tree. The assigned tree is prepared for
-         * destrution.
+         * destruction.
          *
          * @param tree the tree to move
          * @return reference to this tree
@@ -859,7 +859,7 @@ namespace wlp {
             typename GetKey, typename GetVal, typename Cmp>
     inline typename RedBlackTree<Element, Key, Val, GetKey, GetVal, Cmp>::node_type *
     RedBlackTree<Element, Key, Val, GetKey, GetVal, Cmp>
-    ::eraseRebalance(
+    ::erase_rebalance(
             node_type *node,
             node_type *&root,
             node_type *&leftmost,
@@ -1128,7 +1128,7 @@ namespace wlp {
             typename GetKey, typename GetVal, typename Cmp>
     inline void RedBlackTree<Element, Key, Val, GetKey, GetVal, Cmp>
     ::erase(const iterator &pos) {
-        node_type *carry = eraseRebalance(pos.m_node, m_header->m_parent, m_header->m_left, m_header->m_right);
+        node_type *carry = erase_rebalance(pos.m_node, m_header->m_parent, m_header->m_left, m_header->m_right);
         destroy_node(carry);
         --m_size;
     }

--- a/lib/wlib/stl/Table.h
+++ b/lib/wlib/stl/Table.h
@@ -1,0 +1,55 @@
+#ifndef EMBEDDEDCPLUSPLUS_TABLECOMMON_H
+#define EMBEDDEDCPLUSPLUS_TABLECOMMON_H
+
+#include "Tuple.h"
+#include "../utility/Tmp.h"
+
+namespace wlp {
+
+    template<typename Key, typename Val>
+    struct MapGetKey {
+        typedef Tuple<Key, Val> element_type;
+        typedef Key key_type;
+
+        template<typename E>
+        const key_type &operator()(E &&element) const {
+            return get<0>(forward<E>(element));
+        }
+    };
+
+    template<typename Key, typename Val>
+    struct MapGetVal {
+        typedef Tuple<Key, Val> element_type;
+        typedef Val val_type;
+
+        template<typename E>
+        val_type &operator()(E &&element) const {
+            return get<1>(forward<E>(element));
+        }
+    };
+
+    template<typename Key>
+    struct SetGetKey {
+        typedef Key element_type;
+        typedef Key key_type;
+
+        template<typename E>
+        const key_type &operator()(E &&element) const {
+            return forward<E>(element);
+        }
+    };
+
+    template<typename Key>
+    struct SetGetVal {
+        typedef Key element_type;
+        typedef Key val_type;
+
+        template<typename E>
+        val_type &operator()(E &&element) const {
+            return forward<E>(element);
+        }
+    };
+
+}
+
+#endif //EMBEDDEDCPLUSPLUS_TABLECOMMON_H

--- a/lib/wlib/stl/TreeMap.h
+++ b/lib/wlib/stl/TreeMap.h
@@ -12,8 +12,31 @@
 
 #include "../Types.h"
 #include "RedBlackTree.h"
+#include "Tuple.h"
 
 namespace wlp {
+
+    template<typename Key, typename Val>
+    struct TreeMapGetKey {
+        typedef Tuple<Key, Val> element_type;
+        typedef Key key_type;
+
+        template<typename E>
+        const key_type &operator()(E &&element) const {
+            return get<0>(forward<E>(element));
+        }
+    };
+
+    template<typename Key, typename Val>
+    struct TreeMapGetVal {
+        typedef Tuple<Key, Val> element_type;
+        typedef Val val_type;
+
+        template<typename E>
+        val_type &operator()(E &&element) const {
+            return get<1>(forward<E>(element));
+        }
+    };
 
     /**
      * Map implementation using @code RedBlackTree @endcode as the
@@ -30,11 +53,11 @@ namespace wlp {
     class TreeMap {
     public:
         typedef TreeMap<Key, Val, Cmp> map_type;
-        typedef RedBlackTree<Key, Val, Cmp> table_type;
-        typedef typename RedBlackTree<Key, Val, Cmp>::node_type node_type;
-        typedef typename RedBlackTree<Key, Val, Cmp>::iterator iterator;
-        typedef typename RedBlackTree<Key, Val, Cmp>::const_iterator const_iterator;
-        typedef typename RedBlackTree<Key, Val, Cmp>::size_type size_type;
+        typedef RedBlackTree<Key, Val, Cmp, TreeMapGetKey<Key, Val>, TreeMapGetVal<Key, Val>> table_type;
+        typedef typename table_type::node_type node_type;
+        typedef typename table_type::iterator iterator;
+        typedef typename table_type::const_iterator const_iterator;
+        typedef typename table_type::size_type size_type;
 
         typedef Key key_type;
         typedef Val val_type;
@@ -91,12 +114,12 @@ namespace wlp {
 
         template<typename K, typename V>
         Pair<iterator, bool> insert(K &&key, V &&val) {
-            return m_tree.insert_unique(forward<K>(key), forward<V>(val));
+            return m_tree.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
         };
 
         template<typename K, typename V>
         Pair<iterator, bool> insert_or_assign(K &&key, V &&val) {
-            Pair<iterator, bool> result = m_tree.insert_unique(forward<K>(key), forward<V>(val));
+            Pair<iterator, bool> result = m_tree.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
             if (!result.m_second) {
                 *result.m_first = forward<V>(val);
             }
@@ -136,7 +159,7 @@ namespace wlp {
 
         template<typename K>
         val_type &operator[](K &&key) {
-            Pair<iterator, bool> result = m_tree.insert_unique(forward<K>(key), val_type());
+            Pair<iterator, bool> result = m_tree.insert_unique(make_tuple(forward<K>(key), val_type()));
             return *result.m_first;
         }
 

--- a/lib/wlib/stl/TreeMap.h
+++ b/lib/wlib/stl/TreeMap.h
@@ -10,33 +10,12 @@
 #ifndef EMBEDDEDCPLUSPLUS_TREEMAP_H
 #define EMBEDDEDCPLUSPLUS_TREEMAP_H
 
-#include "../Types.h"
 #include "RedBlackTree.h"
+#include "Table.h"
 #include "Tuple.h"
+#include "../Types.h"
 
 namespace wlp {
-
-    template<typename Key, typename Val>
-    struct TreeMapGetKey {
-        typedef Tuple<Key, Val> element_type;
-        typedef Key key_type;
-
-        template<typename E>
-        const key_type &operator()(E &&element) const {
-            return get<0>(forward<E>(element));
-        }
-    };
-
-    template<typename Key, typename Val>
-    struct TreeMapGetVal {
-        typedef Tuple<Key, Val> element_type;
-        typedef Val val_type;
-
-        template<typename E>
-        val_type &operator()(E &&element) const {
-            return get<1>(forward<E>(element));
-        }
-    };
 
     /**
      * Map implementation using @code RedBlackTree @endcode as the
@@ -53,8 +32,11 @@ namespace wlp {
     class TreeMap {
     public:
         typedef TreeMap<Key, Val, Cmp> map_type;
-        typedef RedBlackTree<Key, Val, Cmp, TreeMapGetKey<Key, Val>, TreeMapGetVal<Key, Val>> table_type;
-        typedef typename table_type::node_type node_type;
+        typedef RedBlackTree<Tuple<Key, Val>,
+                Key, Val,
+                MapGetKey<Key, Val>, MapGetVal<Key, Val>,
+                Cmp
+        > table_type;
         typedef typename table_type::iterator iterator;
         typedef typename table_type::const_iterator const_iterator;
         typedef typename table_type::size_type size_type;
@@ -63,63 +45,63 @@ namespace wlp {
         typedef Val val_type;
 
     private:
-        table_type m_tree;
+        table_type m_table;
 
     public:
         explicit TreeMap()
-                : m_tree() {
+                : m_table() {
         }
 
         TreeMap(const map_type &) = delete;
 
         TreeMap(map_type &&map)
-                : m_tree(move(map.m_tree)) {
+                : m_table(move(map.m_table)) {
         }
 
         size_type size() const {
-            return m_tree.size();
+            return m_table.size();
         }
 
         size_type capacity() const {
-            return m_tree.capacity();
+            return m_table.capacity();
         }
 
         bool empty() const {
-            return m_tree.empty();
+            return m_table.empty();
         }
 
         const table_type *get_backing_table() const {
-            return &m_tree;
+            return &m_table;
         }
 
         iterator begin() {
-            return m_tree.begin();
+            return m_table.begin();
         }
 
         const_iterator begin() const {
-            return m_tree.begin();
+            return m_table.begin();
         }
 
         iterator end() {
-            return m_tree.end();
+            return m_table.end();
         }
 
         const_iterator end() const {
-            return m_tree.end();
+            return m_table.end();
         }
 
         void clear() noexcept {
-            m_tree.clear();
+            m_table.clear();
         }
 
         template<typename K, typename V>
         Pair<iterator, bool> insert(K &&key, V &&val) {
-            return m_tree.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
+            return m_table.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
         };
 
         template<typename K, typename V>
         Pair<iterator, bool> insert_or_assign(K &&key, V &&val) {
-            Pair<iterator, bool> result = m_tree.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
+            Pair<iterator, bool> result = m_table.insert_unique(make_tuple(forward<K>(key), forward<V>(val)));
             if (!result.m_second) {
                 *result.m_first = forward<V>(val);
             }
@@ -129,44 +111,44 @@ namespace wlp {
         iterator erase(const iterator &pos) {
             iterator tmp = pos;
             ++tmp;
-            m_tree.erase(pos);
+            m_table.erase(pos);
             return tmp;
         }
 
         bool erase(const key_type &key) {
-            return m_tree.erase(key) > 0;
+            return m_table.erase(key) > 0;
         }
 
         val_type &at(const key_type &key) {
-            return *m_tree.find(key);
+            return *m_table.find(key);
         }
 
         const val_type &at(const key_type &key) const {
-            return *m_tree.find(key);
+            return *m_table.find(key);
         }
 
         bool contains(const key_type &key) const {
-            return m_tree.find(key) != m_tree.end();
+            return m_table.find(key) != m_table.end();
         }
 
         iterator find(const key_type &key) {
-            return m_tree.find(key);
+            return m_table.find(key);
         }
 
         const_iterator find(const key_type &key) const {
-            return m_tree.find(key);
+            return m_table.find(key);
         }
 
         template<typename K>
         val_type &operator[](K &&key) {
-            Pair<iterator, bool> result = m_tree.insert_unique(make_tuple(forward<K>(key), val_type()));
+            Pair<iterator, bool> result = m_table.insert_unique(make_tuple(forward<K>(key), val_type()));
             return *result.m_first;
         }
 
         map_type &operator=(const map_type &) = delete;
 
         map_type &operator=(map_type &&map) {
-            m_tree = move(map.m_tree);
+            m_table = move(map.m_table);
             return *this;
         }
     };

--- a/lib/wlib/stl/TreeSet.h
+++ b/lib/wlib/stl/TreeSet.h
@@ -10,31 +10,10 @@
 #ifndef EMBEDDEDCPLUSPLUS_TREESET_H
 #define EMBEDDEDCPLUSPLUS_TREESET_H
 
+#include "Table.h"
 #include "RedBlackTree.h"
 
 namespace wlp {
-
-    template<typename Key>
-    struct TreeSetGetKey {
-        typedef Key element_type;
-        typedef Key key_type;
-
-        template<typename E>
-        const key_type &operator()(E &&element) const {
-            return forward<E>(element);
-        }
-    };
-
-    template<typename Key>
-    struct TreeSetGetVal {
-        typedef Key element_type;
-        typedef Key val_type;
-
-        template<typename E>
-        val_type &operator()(E &&element) const {
-            return forward<E>(element);
-        }
-    };
 
     /**
      * Set implementation using @code RedBlackTree @endcode as the
@@ -50,7 +29,11 @@ namespace wlp {
     class TreeSet {
     public:
         typedef TreeSet<Key, Cmp> set_type;
-        typedef RedBlackTree<Key, Key, Cmp, TreeSetGetKey<Key>, TreeSetGetVal<Key>> table_type;
+        typedef RedBlackTree<Key,
+            Key, Key,
+            SetGetKey<Key>, SetGetVal<Key>,
+            Cmp
+        > table_type;
         typedef typename table_type::iterator iterator;
         typedef typename table_type::const_iterator const_iterator;
         typedef typename table_type::size_type size_type;
@@ -58,87 +41,87 @@ namespace wlp {
         typedef Key key_type;
 
     private:
-        table_type m_tree;
+        table_type m_table;
 
     public:
         explicit TreeSet()
-                : m_tree() {
+                : m_table() {
         }
 
         TreeSet(const set_type &) = delete;
 
         TreeSet(set_type &&set)
-                : m_tree(move(set.m_tree)) {
+                : m_table(move(set.m_table)) {
         }
 
         size_type size() const {
-            return m_tree.size();
+            return m_table.size();
         }
 
         size_type capacity() const {
-            return m_tree.capacity();
+            return m_table.capacity();
         }
 
         bool empty() const {
-            return m_tree.empty();
+            return m_table.empty();
         }
 
         const table_type *get_backing_table() const {
-            return &m_tree;
+            return &m_table;
         }
 
         iterator begin() {
-            return m_tree.begin();
+            return m_table.begin();
         }
 
         const_iterator begin() const {
-            return m_tree.begin();
+            return m_table.begin();
         }
 
         iterator end() {
-            return m_tree.end();
+            return m_table.end();
         }
 
         const_iterator end() const {
-            return m_tree.end();
+            return m_table.end();
         }
 
         void clear() noexcept {
-            m_tree.clear();
+            m_table.clear();
         }
 
         template<typename K>
         Pair<iterator, bool> insert(K &&key) {
-            return m_tree.insert_unique(key);
+            return m_table.insert_unique(key);
         };
 
         bool contains(const key_type &key) const {
-            return m_tree.find(key) != m_tree.end();
+            return m_table.find(key) != m_table.end();
         }
 
         iterator find(const key_type &key) {
-            return m_tree.find(key);
+            return m_table.find(key);
         }
 
         const_iterator find(const key_type &key) const {
-            return m_tree.find(key);
+            return m_table.find(key);
         }
 
         iterator erase(const iterator &pos) {
             iterator tmp = pos;
             ++tmp;
-            m_tree.erase(pos);
+            m_table.erase(pos);
             return tmp;
         }
 
         bool erase(const key_type &key) {
-            return m_tree.erase(key) > 0;
+            return m_table.erase(key) > 0;
         }
 
         set_type &operator=(const set_type &) = delete;
 
         set_type &operator=(set_type &&set) {
-            m_tree = move(set.m_tree);
+            m_table = move(set.m_table);
             return *this;
         }
 

--- a/lib/wlib/stl/TreeSet.h
+++ b/lib/wlib/stl/TreeSet.h
@@ -14,6 +14,28 @@
 
 namespace wlp {
 
+    template<typename Key>
+    struct TreeSetGetKey {
+        typedef Key element_type;
+        typedef Key key_type;
+
+        template<typename E>
+        const key_type &operator()(E &&element) const {
+            return forward<E>(element);
+        }
+    };
+
+    template<typename Key>
+    struct TreeSetGetVal {
+        typedef Key element_type;
+        typedef Key val_type;
+
+        template<typename E>
+        val_type &operator()(E &&element) const {
+            return forward<E>(element);
+        }
+    };
+
     /**
      * Set implementation using @code RedBlackTree @endcode as the
      * backing data structure.
@@ -28,10 +50,10 @@ namespace wlp {
     class TreeSet {
     public:
         typedef TreeSet<Key, Cmp> set_type;
-        typedef RedBlackTree<Key, Key, Cmp> table_type;
-        typedef typename RedBlackTree<Key, Key, Cmp>::iterator iterator;
-        typedef typename RedBlackTree<Key, Key, Cmp>::const_iterator const_iterator;
-        typedef typename RedBlackTree<Key, Key, Cmp>::size_type size_type;
+        typedef RedBlackTree<Key, Key, Cmp, TreeSetGetKey<Key>, TreeSetGetVal<Key>> table_type;
+        typedef typename table_type::iterator iterator;
+        typedef typename table_type::const_iterator const_iterator;
+        typedef typename table_type::size_type size_type;
 
         typedef Key key_type;
 
@@ -87,7 +109,7 @@ namespace wlp {
 
         template<typename K>
         Pair<iterator, bool> insert(K &&key) {
-            return m_tree.insert_unique(forward<K>(key), forward<K>(key));
+            return m_tree.insert_unique(key);
         };
 
         bool contains(const key_type &key) const {

--- a/tests/stl/open_map_check.cpp
+++ b/tests/stl/open_map_check.cpp
@@ -283,12 +283,10 @@ TEST(open_map_test, test_erase_iterator_invalid_node) {
     map[0] = 0;
     map[1] = 10;
     map[2] = 20;
-    int_map::node_type invalid_node;
-    invalid_node.m_key = 10;
-    invalid_node.m_val = 100;
+    int_map::table_type::element_type invalid_node = make_tuple(10, 100);
     int_map::iterator it;
     it.m_current = &invalid_node;
-    it.m_hash_map = &map;
+    it.m_table = map.get_backing_table();
     ASSERT_EQ(map.end(), map.erase(it));
 }
 

--- a/tests/stl/red_black_tree_check.cpp
+++ b/tests/stl/red_black_tree_check.cpp
@@ -5,22 +5,28 @@
 #include "stl/ArrayList.h"
 #include "stl/ArrayHeap.h"
 #include "stl/RedBlackTree.h"
+#include "stl/Tuple.h"
+#include "stl/TreeMap.h"
 
 #include "../test_helper.h"
 
 using namespace wlp;
 
-typedef RedBlackTree<char, int>::iterator rbi;
-typedef RedBlackTree<char, int> rb_tree;
+typedef Tuple<char, int> _rb_element;
+typedef TreeMapGetKey<char, int> _rb_key;
+typedef TreeMapGetVal<char, int> _rb_val;
+
+typedef typename RedBlackTree<_rb_element, char, int, _rb_key, _rb_val>::iterator rbi;
+typedef RedBlackTree<_rb_element, char, int, _rb_key, _rb_val> rb_tree;
 
 TEST(rb_tree_test, test_insert_iterator_order) {
     char keys[] = {'g', 'h', 'j', 'k', 'y', 'c', 'd', 'q', 'w'};
     int vals[] = {5, 1, 0, 9, -1, -4, 12, 10, -66};
     OpenHashMap<char, int> val_map(20);
-    RedBlackTree<char, int> tree;
+    rb_tree tree;
     for (size_type i = 0; i < 9; i++) {
         val_map.insert(keys[i], vals[i]);
-        Pair<rbi, bool> res = tree.insert_unique(keys[i], vals[i]);
+        Pair<rbi, bool> res = tree.insert_unique(make_tuple(keys[i], vals[i]));
         ASSERT_TRUE(res.second());
         ASSERT_EQ(vals[i], *res.first());
     }
@@ -31,7 +37,7 @@ TEST(rb_tree_test, test_insert_iterator_order) {
     for (size_type i = 0; i < key_list.size(); i++) {
         char expected_key = key_list[i];
         int expected_val = val_map[expected_key];
-        char key = it.key();
+        char key = get<0>(it.m_node->m_element);
         int val = *it;
         ASSERT_EQ(expected_key, key);
         ASSERT_EQ(expected_val, val);
@@ -53,7 +59,7 @@ TEST(rb_tree_test, test_insert_unique_find) {
     OpenHashSet<char> key_set(80);
     for (int i = 0; i < 40; i++) {
         vals[i] = random_int();
-        Pair<rbi, bool> res = tree.insert_unique(keys[i], vals[i]);
+        Pair<rbi, bool> res = tree.insert_unique(make_tuple(keys[i], vals[i]));
         if (key_set.contains(keys[i])) {
             ASSERT_FALSE(res.second());
         } else {
@@ -70,16 +76,16 @@ TEST(rb_tree_test, test_insert_unique_find) {
     ReverseComparator<char> cmp;
     heap_sort(key_list, cmp);
     for (int i = 0; i < 40; i++) {
-        Pair<rbi, bool> res = tree.insert_unique(keys[i], vals[i]);
+        Pair<rbi, bool> res = tree.insert_unique(make_tuple(keys[i], vals[i]));
         ASSERT_FALSE(res.second());
         ASSERT_EQ(val_map[keys[i]], *res.first());
-        ASSERT_EQ(keys[i], res.first().key());
+        ASSERT_EQ(keys[i], get<0>(res.first().m_node->m_element));
     }
     ASSERT_EQ(key_set.size(), tree.size());
     int count = 0;
     ArrayList<char>::iterator kit = key_list.begin();
     for (rbi it = --tree.end();; --it) {
-        ASSERT_EQ(*kit, it.key());
+        ASSERT_EQ(*kit, get<0>(it.m_node->m_element));
         ASSERT_EQ(val_map[*kit], *it);
         ++kit;
         if (it == tree.begin()) {
@@ -106,9 +112,9 @@ TEST(rb_tree_test, test_insert_equal_and_range) {
     size_type cnt = 10;
     rb_tree tree;
     for (int i = 0; i < cnt; i++) {
-        rbi it = tree.insert_equal(keys[i], values[i]);
+        rbi it = tree.insert_equal(make_tuple(keys[i], values[i]));
         ASSERT_EQ(values[i], *it);
-        ASSERT_EQ(keys[i], it.key());
+        ASSERT_EQ(keys[i], get<0>(it.m_node->m_element));
         val_set.insert(values[i]);
     }
     char ukeys[] = {'a', 'b', 'c', 'd'};

--- a/tests/stl/red_black_tree_check.cpp
+++ b/tests/stl/red_black_tree_check.cpp
@@ -4,6 +4,7 @@
 
 #include "stl/ArrayList.h"
 #include "stl/ArrayHeap.h"
+#include "stl/OpenMap.h"
 #include "stl/RedBlackTree.h"
 #include "stl/Tuple.h"
 #include "stl/TreeMap.h"
@@ -13,8 +14,8 @@
 using namespace wlp;
 
 typedef Tuple<char, int> _rb_element;
-typedef TreeMapGetKey<char, int> _rb_key;
-typedef TreeMapGetVal<char, int> _rb_val;
+typedef MapGetKey<char, int> _rb_key;
+typedef MapGetVal<char, int> _rb_val;
 
 typedef typename RedBlackTree<_rb_element, char, int, _rb_key, _rb_val>::iterator rbi;
 typedef RedBlackTree<_rb_element, char, int, _rb_key, _rb_val> rb_tree;

--- a/tests/template_defs.h
+++ b/tests/template_defs.h
@@ -92,42 +92,6 @@ namespace wlp {
     struct Pair<OpenHashMap<String16, String16>::iterator, bool>;
 
     template
-    struct OpenHashMapIterator<
-            String16,
-            String16,
-            String16 &,
-            String16 *,
-            Hash<String16, uint16_t>,
-            Equal<String16>>;
-
-    template
-    struct OpenHashMapIterator<
-            uint16_t,
-            uint16_t,
-            uint16_t &,
-            uint16_t *,
-            Hash<uint16_t, uint16_t>,
-            Equal<uint16_t>>;
-
-    template
-    struct OpenHashMapIterator<
-            String16,
-            String16,
-            const String16 &,
-            const String16 *,
-            Hash<String16, uint16_t>,
-            Equal<String16>>;
-
-    template
-    struct OpenHashMapIterator<
-            uint16_t,
-            uint16_t,
-            const uint16_t &,
-            const uint16_t *,
-            Hash<uint16_t, uint16_t>,
-            Equal<uint16_t>>;
-
-    template
     class ArrayHeap<int>;
 
     template


### PR DESCRIPTION
This was a pain in the ass.

Tests for `TreeSet` and `TreeMap` were not modified at all, so semantics have not changed. Test for `RedBlackTree` slightly modified because function signatures have changed to allow the wrapper type.

`RedBlackTree` is now more amenable to MultiMaps and MultiSets if we need them later on